### PR TITLE
corrected JUnit dependency to 4.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>3.8.1</version>
+            <version>4.11</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
We migrated to JUnit 4.x. This was not reflected in the pom.xml file.
As current version we use 4.11
