### PR TITLE
Workaround for GLAZEDLISTS-564/JDK-8054478

### DIFF
--- a/source/ca/odell/glazedlists/impl/filter/BoyerMooreCaseInsensitiveTextSearchStrategy.java
+++ b/source/ca/odell/glazedlists/impl/filter/BoyerMooreCaseInsensitiveTextSearchStrategy.java
@@ -104,13 +104,16 @@ public class BoyerMooreCaseInsensitiveTextSearchStrategy extends AbstractTextSea
                       (this.subtextCharsLower[subtextPosition] == textChar ||
                        this.subtextCharsUpper[subtextPosition] == textChar)) {
                     // the text char and subtext char matched, so shift both positions left and recompare
-                    subtextPosition--;
+					// subtextPosition--;
                     textPosition--;
 
                     // calculate the next character of the text to compare
                     if(textPosition != -1) {
                         textChar = map(text.charAt(textPosition));
                     }
+					// workaround
+					// https://bugs.openjdk.java.net/browse/JDK-8054478
+					subtextPosition--;
                 }
             }
 
@@ -128,4 +131,5 @@ public class BoyerMooreCaseInsensitiveTextSearchStrategy extends AbstractTextSea
         // if we fall out of the search loop then we couldn't find the subtext
         return -1;
     }
+    
 }


### PR DESCRIPTION
This is a workaround for https://java.net/jira/browse/GLAZEDLISTS-564 which is caused by https://bugs.openjdk.java.net/browse/JDK-8054478 

The following test case will crash on the following JDK's (64bit only) 1.7.51, 1.7.60, 1.8.05 and 1.8.25
```java
public class CrashBoyerMooreCaseInsensitiveTextSearchStrategy {
	static void test(String s) {
		BoyerMooreCaseInsensitiveTextSearchStrategy b = new BoyerMooreCaseInsensitiveTextSearchStrategy();
		b.setSubtext(s);
		b.indexOf("Saskatchewan Roughriders");
	}
	public static void main(String[] args) {
		for (int i = 0; i < 10000000; i++) {
			test("Sask");
			test("S");
		}
	}
}
```
Moving `subtextPosition--` to the bottom of the while loop eliminates the crash. 

