### PR TITLE
Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-install: ant test
+script: ant test
 language: java
 jdk:
   - oraclejdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ language: java
 jdk:
   - oraclejdk7
   - oraclejdk8
+sudo: false
+install: true

--- a/test/ca/odell/glazedlists/impl/swt/SWTThreadProxyCalculationTest.java
+++ b/test/ca/odell/glazedlists/impl/swt/SWTThreadProxyCalculationTest.java
@@ -18,10 +18,7 @@ import java.util.Arrays;
 
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 
 import static org.junit.Assert.*;
 
@@ -45,6 +42,10 @@ public class SWTThreadProxyCalculationTest {
 
     @Before
     public void setUp() {
+        // TODO: SWT tests only work reliably on Windows
+        Assume.assumeTrue( "Test is only reliable on Windows",
+            System.getProperty( "os.name" ).contains( "Windows" ) );
+
         source = new BasicEventList<String>();
         countCalc = Calculations.count(source);
         countProxyCalc = CalculationsSWT.swtThreadProxyCalculation(countCalc, swtClassRule.getDisplay());

--- a/test/ca/odell/glazedlists/swing/TableComparatorChooserTest.java
+++ b/test/ca/odell/glazedlists/swing/TableComparatorChooserTest.java
@@ -6,14 +6,10 @@ import ca.odell.glazedlists.GlazedLists;
 import ca.odell.glazedlists.SortedList;
 import ca.odell.glazedlists.gui.AbstractTableComparatorChooser;
 import ca.odell.glazedlists.gui.TableFormat;
-
-import javax.swing.JLabel;
-import javax.swing.JTable;
-import javax.swing.SwingUtilities;
-import javax.swing.UIManager;
-import javax.swing.table.TableCellRenderer;
-
 import org.junit.Test;
+
+import javax.swing.*;
+import javax.swing.table.TableCellRenderer;
 
 public class TableComparatorChooserTest extends SwingTestCase {
 
@@ -29,12 +25,12 @@ public class TableComparatorChooserTest extends SwingTestCase {
         SortedList<JLabel> sorted = new SortedList<JLabel>(source);
         TableComparatorChooser.install(table, sorted, AbstractTableComparatorChooser.SINGLE_COLUMN);
 
-        // install the Windows LnF
-        UIManager.setLookAndFeel("com.sun.java.swing.plaf.windows.WindowsLookAndFeel");
+        // install the System LnF
+        UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
         SwingUtilities.updateComponentTreeUI(table);
 
-        // install the Windows LnF
-        UIManager.setLookAndFeel("com.sun.java.swing.plaf.motif.MotifLookAndFeel");
+        // install the Cross-platform LnF
+        UIManager.setLookAndFeel(UIManager.getCrossPlatformLookAndFeelClassName());
         SwingUtilities.updateComponentTreeUI(table);
 
         // this line throws an NPE without a fix from GL

--- a/test/ca/odell/glazedlists/swing/TreeTableSupportTest.java
+++ b/test/ca/odell/glazedlists/swing/TreeTableSupportTest.java
@@ -179,6 +179,35 @@ public class TreeTableSupportTest extends SwingTestCase {
         assertEquals(IllegalStateException.class, r.getRuntimeException().getClass());
     }
 
+	@Test
+	public void testKeepSelectionWhenUpdatingElements()	throws InterruptedException {
+		// build a TreeList
+		final EventList<String> source = new BasicEventList<String>();
+		final TreeList<String> treeList = new TreeList<String>(source, TreeListTest.UNCOMPRESSED_CHARACTER_TREE_FORMAT,	TreeList.<String> nodesStartExpanded());
+		final EventList<String> proxyList = GlazedListsSwing.swingThreadProxyList(treeList);
+
+		// build a regular JTable around the TreeList
+		final TableFormat<String> itemTableFormat = GlazedLists.tableFormat(new String[] { "" }, new String[] { "Column 1" });
+		final DefaultEventTableModel<String> model = new DefaultEventTableModel<String>(proxyList, itemTableFormat);
+		final JTable table = new JTable(model);
+
+		// install TreeTableSupport
+		TreeTableSupport.install(table, treeList, 0);
+
+		source.add(0, "A");
+		source.add(1, "B");
+		source.add(2, "C");
+		source.add(3, "D");
+
+		table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+		table.setRowSelectionAllowed(true);
+		table.setRowSelectionInterval(0, 0);
+
+		assertEquals(0, table.getSelectedRow());
+		source.set(0, "A");
+		assertEquals(0, table.getSelectedRow());
+	}
+
     /**
      * A Runnable that tries to execute an operation on an EventList and records
      * any resulting RuntimeException which is expected.

--- a/test/ca/odell/glazedlists/swt/SwtClassRule.java
+++ b/test/ca/odell/glazedlists/swt/SwtClassRule.java
@@ -3,14 +3,15 @@
 /*                                                     O'Dell Engineering Ltd.*/
 package ca.odell.glazedlists.swt;
 
-import java.util.concurrent.CountDownLatch;
-
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
+import org.junit.Assume;
 import org.junit.ClassRule;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
+
+import java.util.concurrent.CountDownLatch;
 
 /**
  * A {@link TestRule} that initializes the SWT environment (display and shell)
@@ -43,6 +44,10 @@ public class SwtClassRule implements TestRule {
     }
 
     private void init() throws InterruptedException {
+        // TODO: SWT tests only work reliably on Windows
+        Assume.assumeTrue( "Test is only reliable on Windows",
+            System.getProperty( "os.name" ).contains( "Windows" ) );
+
         final CountDownLatch latch = new CountDownLatch(1);
         guiThread = new SwtThread(latch);
         guiThread.start();


### PR DESCRIPTION
Changes to allow tests to pass in Travis builds and config changes for the build itself.
- Moved "ant test" call into the "script" step for Travis.
- SWT tests are ignored except on Windows, which is the only place they seem to work.
- In TableComparatorChooserTest, use more generally available LnF's.
- Fix incorrect assumption of number of listeners in TreeTableSupportTest.