### PR TITLE
Fixed ObservableElementList producing invalid change events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+target/
+.project
+.classpath
+.settings/
+.idea/
+*.iml
+*.ipr
+*.iws
+extensions/*/lib/
+tools/

--- a/source/ca/odell/glazedlists/ObservableElementList.java
+++ b/source/ca/odell/glazedlists/ObservableElementList.java
@@ -419,8 +419,8 @@ public class ObservableElementList<E> extends TransformedList<E, E> {
             this.updates.beginEvent();
 
             // locate all indexes containing the given listElement
-            for (int i = 0, n = size(); i < n; i++) {
-            	final E currentElement = get(i);
+            for (int i = 0, n = this.observedElements.size(); i < n; i++) {
+            	final E currentElement = this.observedElements.get(i);
                 if (listElement == currentElement) {
                     this.updates.elementUpdated(i, currentElement);
                 }


### PR DESCRIPTION
I had a list structure where elements get modified by a ListEventListener, and an ObservableElementList listened for these changes. The ListEventPublisher is configured so the ObservableElementList's listChanged is executed later. However, the ListEvents produced by the ObservableElementList were invalid when elements got added to the source list.

The reason for this is the fact that when looking up the index of an updated element in elementUpdated, it would use `this.get()`, which delegates to the source list which already does contain the inserted elements, even though the insertion event is only processed later.

This pull request fixes this by looking up the elements in the local copy `this.observedElements` instead.
