### PR TITLE
Feature/locks

### DIFF
--- a/source/ca/odell/glazedlists/util/concurrent/J2SE50LockFactory.java
+++ b/source/ca/odell/glazedlists/util/concurrent/J2SE50LockFactory.java
@@ -5,6 +5,8 @@ package ca.odell.glazedlists.util.concurrent;
 
 import java.io.ObjectStreamException;
 import java.io.Serializable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
@@ -93,5 +95,20 @@ final class LockAdapter implements Lock {
     @Override
     public void unlock() {
         delegateLock.unlock();
+    }
+
+    @Override
+    public void lockInterruptibly() throws InterruptedException {
+        delegateLock.lockInterruptibly();
+    }
+
+    @Override
+    public boolean tryLock(long time, TimeUnit unit) throws InterruptedException {
+        return delegateLock.tryLock(time, unit);
+    }
+
+    @Override
+    public Condition newCondition() {
+        return delegateLock.newCondition();
     }
 }

--- a/source/ca/odell/glazedlists/util/concurrent/Lock.java
+++ b/source/ca/odell/glazedlists/util/concurrent/Lock.java
@@ -21,15 +21,18 @@ public interface Lock extends java.util.concurrent.locks.Lock {
     /**
      * Acquires the lock.
      */
+    @Override
     public void lock();
 
     /**
      * Acquires the lock only if it is free at the time of invocation.
      */
+    @Override
     public boolean tryLock();
 
     /**
      * Releases the lock.
      */
+    @Override
     public void unlock();
 }

--- a/source/ca/odell/glazedlists/util/concurrent/Lock.java
+++ b/source/ca/odell/glazedlists/util/concurrent/Lock.java
@@ -16,7 +16,7 @@ package ca.odell.glazedlists.util.concurrent;
  *
  * @author <a href="mailto:jesse@swank.ca">Jesse Wilson</a>
  */
-public interface Lock {
+public interface Lock extends java.util.concurrent.locks.Lock {
 
     /**
      * Acquires the lock.

--- a/source/ca/odell/glazedlists/util/concurrent/ReadWriteLock.java
+++ b/source/ca/odell/glazedlists/util/concurrent/ReadWriteLock.java
@@ -18,7 +18,7 @@ package ca.odell.glazedlists.util.concurrent;
  *
  * @author <a href="mailto:jesse@swank.ca">Jesse Wilson</a>
  */
-public interface ReadWriteLock {
+public interface ReadWriteLock extends java.util.concurrent.locks.ReadWriteLock {
 
     /**
      * Return the lock used for reading.


### PR DESCRIPTION
Lock and ReadWriteLock extends the Java5 counter part.
This allows a smooth migration to the jdk classes.