### PR TITLE
Separator list fixes

### DIFF
--- a/core/src/main/java/ca/odell/glazedlists/GroupingList.java
+++ b/core/src/main/java/ca/odell/glazedlists/GroupingList.java
@@ -150,7 +150,7 @@ public final class GroupingList<E> extends TransformedList<E, List<E>> {
      */
     private class GrouperClient implements Grouper.Client<E> {
         @Override
-        public void groupChanged(int index, int groupIndex, int groupChangeType, boolean primary, int elementChangeType, E oldValue, E newValue, boolean updateNextSeparator) {
+        public void groupChanged(int index, int groupIndex, int groupChangeType, boolean primary, int elementChangeType, E oldValue, E newValue, boolean updateNextSeparator, boolean joinRight) {
             if(groupChangeType == ListEvent.INSERT) {
                 insertGroupList(groupIndex);
                 updates.addInsert(groupIndex);

--- a/core/src/main/java/ca/odell/glazedlists/GroupingList.java
+++ b/core/src/main/java/ca/odell/glazedlists/GroupingList.java
@@ -150,7 +150,7 @@ public final class GroupingList<E> extends TransformedList<E, List<E>> {
      */
     private class GrouperClient implements Grouper.Client<E> {
         @Override
-        public void groupChanged(int index, int groupIndex, int groupChangeType, boolean primary, int elementChangeType, E oldValue, E newValue) {
+        public void groupChanged(int index, int groupIndex, int groupChangeType, boolean primary, int elementChangeType, E oldValue, E newValue, boolean updateNextSeparator) {
             if(groupChangeType == ListEvent.INSERT) {
                 insertGroupList(groupIndex);
                 updates.addInsert(groupIndex);

--- a/core/src/main/java/ca/odell/glazedlists/SeparatorList.java
+++ b/core/src/main/java/ca/odell/glazedlists/SeparatorList.java
@@ -638,30 +638,32 @@ public class SeparatorList<E> extends TransformedList<E, E> {
         private class GrouperClient implements Grouper.Client<E> {
             @Override
             public void groupChanged(int index, int groupIndex, int groupChangeType, boolean primary, int elementChangeType, E oldValue, E newValue, boolean updateNextSeparator) {
-                boolean fixSeparatorForInsertGroupUpdateElement = false;
-                // handle the group change first
-                if(groupChangeType == ListEvent.INSERT) {
-                    int expandedIndex = index + groupIndex;
-                    insertedSeparators.add(expandedIndex, SEPARATOR, 1);
-                    updates.addInsert(expandedIndex);
-                    // add the separator and link the separator to its node
-                    Element<GroupSeparator> node = separators.add(groupIndex, new GroupSeparator(), 1);
-                    node.get().setNode(node);
-                    node.get().setLimit(defaultLimit);
-                } else if(groupChangeType == ListEvent.UPDATE) {
-                    int expandedIndex = insertedSeparators.getIndex(groupIndex, SEPARATOR);
-                    updates.addUpdate(expandedIndex);
-                } else if(groupChangeType == ListEvent.DELETE) {
-                    int expandedIndex = insertedSeparators.getIndex(groupIndex, SEPARATOR);
-                    insertedSeparators.remove(expandedIndex, 1);
-                    updates.addDelete(expandedIndex);
-                    // invalidate the node
-                    Element<GroupSeparator> node = separators.get(groupIndex);
-                    separators.remove(node);
-                    node.get().setNode(null);
-                    node.get().updateCachedValues();
-                    groupIndex--;
-                }
+
+                    boolean fixSeparatorForInsertGroupUpdateElement = false;
+                    // handle the group change first
+                    if (groupChangeType == ListEvent.INSERT) {
+                        int expandedIndex = index + groupIndex;
+                        insertedSeparators.add(expandedIndex, SEPARATOR, 1);
+                        updates.addInsert(expandedIndex);
+                        // add the separator and link the separator to its node
+                        Element<GroupSeparator> node = separators.add(groupIndex, new GroupSeparator(), 1);
+                        node.get().setNode(node);
+                        node.get().setLimit(defaultLimit);
+                    } else if (groupChangeType == ListEvent.UPDATE) {
+                        groupIndex = Math.min(groupIndex, insertedSeparators.blackSize() - 1);
+                        int expandedIndex = insertedSeparators.getIndex(groupIndex, SEPARATOR);
+                        updates.addUpdate(expandedIndex);
+                    } else if (groupChangeType == ListEvent.DELETE) {
+                        int expandedIndex = insertedSeparators.getIndex(groupIndex, SEPARATOR);
+                        insertedSeparators.remove(expandedIndex, 1);
+                        updates.addDelete(expandedIndex);
+                        // invalidate the node
+                        Element<GroupSeparator> node = separators.get(groupIndex);
+                        separators.remove(node);
+                        node.get().setNode(null);
+                        node.get().updateCachedValues();
+                        groupIndex--;
+                    }
 
                 // then handle the element change
                 if(elementChangeType == ListEvent.INSERT) {

--- a/core/src/main/java/ca/odell/glazedlists/SeparatorList.java
+++ b/core/src/main/java/ca/odell/glazedlists/SeparatorList.java
@@ -637,7 +637,7 @@ public class SeparatorList<E> extends TransformedList<E, E> {
          */
         private class GrouperClient implements Grouper.Client<E> {
             @Override
-            public void groupChanged(int index, int groupIndex, int groupChangeType, boolean primary, int elementChangeType, E oldValue, E newValue) {
+            public void groupChanged(int index, int groupIndex, int groupChangeType, boolean primary, int elementChangeType, E oldValue, E newValue, boolean updateNextSeparator) {
                 boolean fixSeparatorForInsertGroupUpdateElement = false;
                 // handle the group change first
                 if(groupChangeType == ListEvent.INSERT) {
@@ -738,7 +738,8 @@ public class SeparatorList<E> extends TransformedList<E, E> {
                 // separator positions accordingly
                 if (groupChangeType == ListEvent.UPDATE && elementChangeType == ListEvent.UPDATE
                         && shiftGroupIndex < insertedSeparators.colourSize(SEPARATOR)
-                        && shiftGroupIndex < grouper.getBarcode().colourSize(Grouper.UNIQUE)) {
+                        && shiftGroupIndex < grouper.getBarcode().colourSize(Grouper.UNIQUE)
+                        && updateNextSeparator) {
                     // when we have an element update and a group update we check and synchronize
                     // the separator position of the next group with the help of the grouper barcode unique index
                     int collapsedGroupStartIndex = grouper.getBarcode().getIndex(shiftGroupIndex, Grouper.UNIQUE);

--- a/core/src/main/java/ca/odell/glazedlists/SeparatorList.java
+++ b/core/src/main/java/ca/odell/glazedlists/SeparatorList.java
@@ -689,6 +689,10 @@ public class SeparatorList<E> extends TransformedList<E, E> {
                     updates.addUpdate(expandedIndex);
                 } else if(elementChangeType == ListEvent.DELETE) {
                     int expandedIndex = index + groupIndex + 1;
+                    // separator in wrong position due to order of events when sorting
+                    if (insertedSeparators.get(expandedIndex) == SEPARATOR) {
+                        shiftSeparator(groupIndex);
+                    }
                     insertedSeparators.remove(expandedIndex, 1);
                     updates.addDelete(expandedIndex);
                 }
@@ -742,22 +746,26 @@ public class SeparatorList<E> extends TransformedList<E, E> {
                         && updateNextSeparator) {
                     // when we have an element update and a group update we check and synchronize
                     // the separator position of the next group with the help of the grouper barcode unique index
-                    int collapsedGroupStartIndex = grouper.getBarcode().getIndex(shiftGroupIndex, Grouper.UNIQUE);
-                    int separatorsIndex = insertedSeparators.getIndex(shiftGroupIndex , SEPARATOR);
-                    int calculatedSeparatorPos = collapsedGroupStartIndex + shiftGroupIndex;
+                    shiftSeparator(shiftGroupIndex);
+                }
+            }
+
+            private void shiftSeparator(int shiftGroupIndex) {
+                int collapsedGroupStartIndex = grouper.getBarcode().getIndex(shiftGroupIndex, Grouper.UNIQUE);
+                int separatorsIndex = insertedSeparators.getIndex(shiftGroupIndex , SEPARATOR);
+                int calculatedSeparatorPos = collapsedGroupStartIndex + shiftGroupIndex;
 //                    String was = insertedSeparators.toString();
-                    if (calculatedSeparatorPos != separatorsIndex) {
-                        // the separator position does not match the grouper barcode -> adjust it
-                        insertedSeparators.remove(separatorsIndex, 1);
-                        updates.addDelete(separatorsIndex);
-                        insertedSeparators.add(calculatedSeparatorPos, SEPARATOR, 1);
-                        // for the update event we have to account for the previous delete
-                        final int insertPos = (calculatedSeparatorPos < separatorsIndex) ? calculatedSeparatorPos
-                                : calculatedSeparatorPos - 1;
-                        updates.addInsert(insertPos);
+                if (calculatedSeparatorPos != separatorsIndex) {
+                    // the separator position does not match the grouper barcode -> adjust it
+                    insertedSeparators.remove(separatorsIndex, 1);
+                    updates.addDelete(separatorsIndex);
+                    insertedSeparators.add(calculatedSeparatorPos, SEPARATOR, 1);
+                    // for the update event we have to account for the previous delete
+                    final int insertPos = (calculatedSeparatorPos < separatorsIndex) ? calculatedSeparatorPos
+                            : calculatedSeparatorPos - 1;
+                    updates.addInsert(insertPos);
 //                        String now = insertedSeparators.toString();
 //                        System.out.println("Changed from " + was + " to " + now);
-                    }
                 }
             }
         }

--- a/core/src/main/java/ca/odell/glazedlists/UniqueList.java
+++ b/core/src/main/java/ca/odell/glazedlists/UniqueList.java
@@ -117,7 +117,7 @@ public final class UniqueList<E> extends TransformedList<E, E> {
      */
     private class GrouperClient implements Grouper.Client<E> {
         @Override
-        public void groupChanged(int index, int groupIndex, int groupChangeType, boolean primary, int elementChangeType, E oldValue, E newValue) {
+        public void groupChanged(int index, int groupIndex, int groupChangeType, boolean primary, int elementChangeType, E oldValue, E newValue, boolean updateNextSeparator) {
             switch (groupChangeType) {
                 case ListEvent.INSERT: updates.elementInserted(groupIndex, newValue); break;
                 case ListEvent.UPDATE: updates.elementUpdated(groupIndex, oldValue, newValue); break;

--- a/core/src/main/java/ca/odell/glazedlists/UniqueList.java
+++ b/core/src/main/java/ca/odell/glazedlists/UniqueList.java
@@ -117,7 +117,7 @@ public final class UniqueList<E> extends TransformedList<E, E> {
      */
     private class GrouperClient implements Grouper.Client<E> {
         @Override
-        public void groupChanged(int index, int groupIndex, int groupChangeType, boolean primary, int elementChangeType, E oldValue, E newValue, boolean updateNextSeparator) {
+        public void groupChanged(int index, int groupIndex, int groupChangeType, boolean primary, int elementChangeType, E oldValue, E newValue, boolean updateNextSeparator, boolean joinRight) {
             switch (groupChangeType) {
                 case ListEvent.INSERT: updates.elementInserted(groupIndex, newValue); break;
                 case ListEvent.UPDATE: updates.elementUpdated(groupIndex, oldValue, newValue); break;

--- a/core/src/main/java/ca/odell/glazedlists/impl/Grouper.java
+++ b/core/src/main/java/ca/odell/glazedlists/impl/Grouper.java
@@ -156,10 +156,10 @@ public class Grouper<E> {
                 // new group (by modifying an element in place). Consequently, we must
                 // mark the NEXT element as UNIQUE and revisit it later to determine if it really is
                 //
-                // GLAZEDLISTS-599: apply this marking only, if there is no UNIQUE element added to the immediate 
+                // GLAZEDLISTS-599: apply this marking only, if there is no UNIQUE element added to the immediate
                 // left that would belong to the same group
                 if (barcode.get(changeIndex) == UNIQUE) {
-                    if (changeIndex+1 < barcode.size() && barcode.get(changeIndex+1) == DUPLICATE 
+                    if (changeIndex+1 < barcode.size() && barcode.get(changeIndex+1) == DUPLICATE
                             && (changeIndex == 0 || !uniqueElementAddedToLeftInSameGroup(toDoList, changeIndex))) {
                         // however, we need to make sure that the barcode UNIQUE entry we are looking at
                         // was part of the barcode state before we started this iteration of listChanges.
@@ -213,9 +213,9 @@ public class Grouper<E> {
                 // if no group already exists to join, create a new group
                 tryJoinExistingGroup(changeIndex, toDoList, tryJoinResult);
                 if(tryJoinResult.group == NO_GROUP) {
-                    client.groupChanged(changeIndex, tryJoinResult.groupIndex, ListEvent.INSERT, true, changeType, ListEvent.<E>unknownValue(), tryJoinResult.newFirstInGroup, false);
+                    client.groupChanged(changeIndex, tryJoinResult.groupIndex, ListEvent.INSERT, true, changeType, ListEvent.<E>unknownValue(), tryJoinResult.newFirstInGroup, false, false);
                 } else {
-                    client.groupChanged(changeIndex, tryJoinResult.groupIndex, ListEvent.UPDATE, true, changeType, tryJoinResult.oldFirstInGroup, tryJoinResult.newFirstInGroup, false);
+                    client.groupChanged(changeIndex, tryJoinResult.groupIndex, ListEvent.UPDATE, true, changeType, tryJoinResult.oldFirstInGroup, tryJoinResult.newFirstInGroup, false, false);
                 }
 
             // updates can result in INSERT, UPDATE and DELETE events
@@ -270,47 +270,47 @@ public class Grouper<E> {
                 // we're the first element in a new group
                 if(tryJoinResult.group == NO_GROUP) {
                     if(oldGroup == NO_GROUP) {
-                        client.groupChanged(changeIndex, groupIndex, ListEvent.UPDATE, true, changeType, oldValue, tryJoinResult.newFirstInGroup, false);
+                        client.groupChanged(changeIndex, groupIndex, ListEvent.UPDATE, true, changeType, oldValue, tryJoinResult.newFirstInGroup, false, false);
                     } else if(oldGroup == LEFT_GROUP) {
                         E firstFromPreviousGroup = sortedList.get(barcode.getIndex(groupIndex - 1, UNIQUE));
-                        client.groupChanged(changeIndex, groupIndex - 1, ListEvent.UPDATE, false, changeType, firstFromPreviousGroup, firstFromPreviousGroup, false);
-                        client.groupChanged(changeIndex, groupIndex, ListEvent.INSERT, true, changeType, ListEvent.<E>unknownValue(), tryJoinResult.newFirstInGroup, false);
+                        client.groupChanged(changeIndex, groupIndex - 1, ListEvent.UPDATE, false, changeType, firstFromPreviousGroup, firstFromPreviousGroup, false, false);
+                        client.groupChanged(changeIndex, groupIndex, ListEvent.INSERT, true, changeType, ListEvent.<E>unknownValue(), tryJoinResult.newFirstInGroup, false, false);
                     } else if(oldGroup == RIGHT_GROUP) {
                         E firstFromNextGroup = sortedList.get(barcode.getIndex(groupIndex + 1, UNIQUE));
-                        client.groupChanged(changeIndex, groupIndex, ListEvent.INSERT, true, changeType, ListEvent.<E>unknownValue(), tryJoinResult.newFirstInGroup, false);
-                        client.groupChanged(changeIndex, groupIndex + 1, ListEvent.UPDATE, false, changeType, oldValue, firstFromNextGroup, false);
+                        client.groupChanged(changeIndex, groupIndex, ListEvent.INSERT, true, changeType, ListEvent.<E>unknownValue(), tryJoinResult.newFirstInGroup, false, false);
+                        client.groupChanged(changeIndex, groupIndex + 1, ListEvent.UPDATE, false, changeType, oldValue, firstFromNextGroup, false, false);
                     }
 
                 // we are joining an existing group to our left
                 } else if(tryJoinResult.group == LEFT_GROUP) {
                     if(oldGroup == NO_GROUP) {
-                        client.groupChanged(changeIndex, groupIndex, ListEvent.UPDATE, true, changeType, tryJoinResult.oldFirstInGroup, tryJoinResult.newFirstInGroup, false);
-                        client.groupChanged(changeIndex, groupIndex + 1, ListEvent.DELETE, false, changeType, oldValue, ListEvent.<E>unknownValue(), false);
+                        client.groupChanged(changeIndex, groupIndex, ListEvent.UPDATE, true, changeType, tryJoinResult.oldFirstInGroup, tryJoinResult.newFirstInGroup, false, false);
+                        client.groupChanged(changeIndex, groupIndex + 1, ListEvent.DELETE, false, changeType, oldValue, ListEvent.<E>unknownValue(), false, false);
                     } else if(oldGroup == LEFT_GROUP) {
-                        client.groupChanged(changeIndex, groupIndex, ListEvent.UPDATE, true, changeType, tryJoinResult.oldFirstInGroup, tryJoinResult.newFirstInGroup, false);
+                        client.groupChanged(changeIndex, groupIndex, ListEvent.UPDATE, true, changeType, tryJoinResult.oldFirstInGroup, tryJoinResult.newFirstInGroup, false, false);
                     } else if(oldGroup == RIGHT_GROUP) {
                         //Update next separator due to Bug500: AACCC -> AAACC
-                        client.groupChanged(changeIndex, groupIndex, ListEvent.UPDATE, true, changeType, tryJoinResult.oldFirstInGroup, tryJoinResult.newFirstInGroup, true);
+                        client.groupChanged(changeIndex, groupIndex, ListEvent.UPDATE, true, changeType, tryJoinResult.oldFirstInGroup, tryJoinResult.newFirstInGroup, true, false);
                         if(groupIndex + 1 < barcode.blackSize()) {
                             E firstFromNextGroup = sortedList.get(barcode.getIndex(groupIndex + 1, UNIQUE));
-                            client.groupChanged(changeIndex, groupIndex + 1, ListEvent.UPDATE, false, changeType, oldValue, firstFromNextGroup, false);
+                            client.groupChanged(changeIndex, groupIndex + 1, ListEvent.UPDATE, false, changeType, oldValue, firstFromNextGroup, false, false);
                         }
                     }
 
                 // we are joining an existing group to our right
                 } else if(tryJoinResult.group == RIGHT_GROUP) {
                     if (oldGroup == NO_GROUP) {
-                        client.groupChanged(changeIndex, groupIndex, ListEvent.DELETE, false, changeType, oldValue, ListEvent.<E>unknownValue(), false);
-                        client.groupChanged(changeIndex, groupIndex, ListEvent.UPDATE, true, changeType, tryJoinResult.oldFirstInGroup, tryJoinResult.newFirstInGroup, false);
+                        client.groupChanged(changeIndex, groupIndex, ListEvent.DELETE, false, changeType, oldValue, ListEvent.<E>unknownValue(), false, true);
+                        client.groupChanged(changeIndex, groupIndex, ListEvent.UPDATE, true, changeType, tryJoinResult.oldFirstInGroup, tryJoinResult.newFirstInGroup, false, true);
                     } else if(oldGroup == LEFT_GROUP) {
                         if(groupIndex - 1 >= 0) {
                             //Update next separator due to Bug500: AAACC -> AACCC
                             E firstFromPreviousGroup = sortedList.get(barcode.getIndex(groupIndex - 1, UNIQUE));
-                            client.groupChanged(changeIndex, groupIndex - 1, ListEvent.UPDATE, false, changeType, firstFromPreviousGroup, firstFromPreviousGroup, true);
+                            client.groupChanged(changeIndex, groupIndex - 1, ListEvent.UPDATE, false, changeType, firstFromPreviousGroup, firstFromPreviousGroup, true, true);
                         }
-                        client.groupChanged(changeIndex, groupIndex, ListEvent.UPDATE, true, changeType, tryJoinResult.oldFirstInGroup, tryJoinResult.newFirstInGroup, false);
+                        client.groupChanged(changeIndex, groupIndex, ListEvent.UPDATE, true, changeType, tryJoinResult.oldFirstInGroup, tryJoinResult.newFirstInGroup, false, true);
                     } else if(oldGroup == RIGHT_GROUP) {
-                        client.groupChanged(changeIndex, groupIndex, ListEvent.UPDATE, true, changeType, tryJoinResult.oldFirstInGroup, tryJoinResult.newFirstInGroup, false);
+                        client.groupChanged(changeIndex, groupIndex, ListEvent.UPDATE, true, changeType, tryJoinResult.oldFirstInGroup, tryJoinResult.newFirstInGroup, false, true);
                     }
                 }
 
@@ -334,11 +334,11 @@ public class Grouper<E> {
                 		// Duplicate deletion is a group update, but it was already triggered by the UNIQUE element update,
                         // so nothing to do here.
                         // For SeparatorList, node still needs to be deleted
-                        client.groupChanged(changeIndex, groupDeletedIndex - 1, ListEvent.UPDATE, true, changeType, oldValue, ListEvent.<E>unknownValue(), false);
+                        client.groupChanged(changeIndex, groupDeletedIndex - 1, ListEvent.UPDATE, true, changeType, oldValue, ListEvent.<E>unknownValue(), false, true);
                         lastFakedUniqueChangeIndex = -1;
                 	} else {
                 		// if we removed a UNIQUE element then it was the last one and we must remove the group
-                		client.groupChanged(changeIndex, groupDeletedIndex, ListEvent.DELETE, true, changeType, oldValue, ListEvent.<E>unknownValue(), false);
+                		client.groupChanged(changeIndex, groupDeletedIndex, ListEvent.DELETE, true, changeType, oldValue, ListEvent.<E>unknownValue(), false, true);
                 	}
                 } else {
                     E oldValueInGroup;
@@ -360,7 +360,7 @@ public class Grouper<E> {
                         oldValueInGroup = newValueInGroup;
                     }
 
-                    client.groupChanged(changeIndex, groupDeletedIndex, ListEvent.UPDATE, true, changeType, oldValueInGroup, newValueInGroup, false);
+                    client.groupChanged(changeIndex, groupDeletedIndex, ListEvent.UPDATE, true, changeType, oldValueInGroup, newValueInGroup, false, true);
                 }
             }
         }
@@ -485,7 +485,8 @@ public class Grouper<E> {
          *      inserted or deleted, in which case the elementChangeType
          * @param updateNextSeparator whether or not we need to consider the
          *      separator update that fixes Bug500
+         * @param joinRight flag to indicate if the right group may need to be shifted
          */
-        public void groupChanged(int index, int groupIndex, int groupChangeType, boolean primary, int elementChangeType, E oldValue, E newValue, boolean updateNextSeparator);
+        public void groupChanged(int index, int groupIndex, int groupChangeType, boolean primary, int elementChangeType, E oldValue, E newValue, boolean updateNextSeparator, boolean joinRight);
     }
 }

--- a/core/src/main/java/ca/odell/glazedlists/impl/Grouper.java
+++ b/core/src/main/java/ca/odell/glazedlists/impl/Grouper.java
@@ -335,6 +335,7 @@ public class Grouper<E> {
                         // so nothing to do here.
                         // For SeparatorList, node still needs to be deleted
                         client.groupChanged(changeIndex, groupDeletedIndex - 1, ListEvent.UPDATE, true, changeType, oldValue, ListEvent.<E>unknownValue(), false);
+                        lastFakedUniqueChangeIndex = -1;
                 	} else {
                 		// if we removed a UNIQUE element then it was the last one and we must remove the group
                 		client.groupChanged(changeIndex, groupDeletedIndex, ListEvent.DELETE, true, changeType, oldValue, ListEvent.<E>unknownValue(), false);

--- a/core/src/main/java/ca/odell/glazedlists/impl/Grouper.java
+++ b/core/src/main/java/ca/odell/glazedlists/impl/Grouper.java
@@ -327,12 +327,14 @@ public class Grouper<E> {
 
                 // fire the change event
                 if(deleted == UNIQUE) {
-                	if (changeIndex == lastFakedUniqueChangeIndex) {
+                	if (changeIndex >= barcode.size() && changeIndex == lastFakedUniqueChangeIndex) {
                 		// case: AACC -> AAC (list change __UX)
                 		// in the last group we have deleted a duplicate element that was marked as UNIQUE
                 		// because of an update event of the preceding UNIQUE element in the first iteration.
                 		// Duplicate deletion is a group update, but it was already triggered by the UNIQUE element update,
-                		// so nothing to do here
+                        // so nothing to do here.
+                        // For SeparatorList, node still needs to be deleted
+                        client.groupChanged(changeIndex, groupDeletedIndex - 1, ListEvent.UPDATE, true, changeType, oldValue, ListEvent.<E>unknownValue(), false);
                 	} else {
                 		// if we removed a UNIQUE element then it was the last one and we must remove the group
                 		client.groupChanged(changeIndex, groupDeletedIndex, ListEvent.DELETE, true, changeType, oldValue, ListEvent.<E>unknownValue(), false);

--- a/core/src/main/java/ca/odell/glazedlists/impl/Grouper.java
+++ b/core/src/main/java/ca/odell/glazedlists/impl/Grouper.java
@@ -258,12 +258,11 @@ public class Grouper<E> {
                     // Without this, the group would change from C__ to AB_ instead.
                     // . Check whether the next element doesn't belong in this group, but it marked as DUPLICATE
                     // . Set it to UNIQUE and the oldGroup to RIGHT_GROUP
-                    if (successor < barcode.size() && barcode.get(successor) == DUPLICATE) {
+                    if (successor < barcode.size() && barcode.get(successor) == DUPLICATE && !groupTogether(changeIndex, successor)) {
                         barcode.set(successor, UNIQUE, 1);
                         oldGroup = RIGHT_GROUP;
                     }
                 }
-
                 // the index of the GroupList being updated (it may or may not exist yet)
                 int groupIndex = tryJoinResult.groupIndex;
 

--- a/core/src/test/java/ca/odell/glazedlists/SeparatorListTest.java
+++ b/core/src/test/java/ca/odell/glazedlists/SeparatorListTest.java
@@ -1484,6 +1484,21 @@ public class SeparatorListTest {
         assertSeparatorEquals(separatorList.get(4), 1, new Element(2, 4));
     }
 
+    @Test
+    public void testUpdateDeleteBug4() {
+        TransactionList<Element> source = createUpdateDeleteElementSource();
+        source.remove(6);
+        SeparatorList<Element> separatorList = new SeparatorList<Element>(source, elementComparator(), 0, Integer.MAX_VALUE);
+
+        source.beginEvent();
+        source.set(3, new Element(2, 4));
+        source.remove(5);
+        source.remove(4);
+        source.commitEvent();
+        assertSeparatorEquals(separatorList.get(0), 3, new Element(1, 1));
+        assertSeparatorEquals(separatorList.get(4), 1, new Element(2, 4));
+    }
+
     private TransactionList<Element> createElementSource() {
         TransactionList<Element> source = new TransactionList<Element>(new BasicEventList<Element>());
         source.add(new Element(1, 1));

--- a/core/src/test/java/ca/odell/glazedlists/SeparatorListTest.java
+++ b/core/src/test/java/ca/odell/glazedlists/SeparatorListTest.java
@@ -933,6 +933,23 @@ public class SeparatorListTest {
         assertEqualsIgnoreSeparators(source, separated, GlazedLists.comparableComparator());
     }
 
+    @Test
+    public void testIssue599() {
+        BasicEventList<String> base = new BasicEventList<String>();
+        base.add("A");
+        base.add("A");
+        TransactionList<String> source = new TransactionList<String>(base);
+        SeparatorList<String> grouped = new SeparatorList<String>(source, String.CASE_INSENSITIVE_ORDER, 1, Integer.MAX_VALUE);
+        ListConsistencyListener<String> listener = ListConsistencyListener.install(grouped, "GROUPED:", true);
+        listener.setPreviousElementTracked(false);
+        source.beginEvent(true);
+        source.add(0, "A");
+        source.set(1, "A");
+        source.add(3, "A");
+        source.commitEvent();
+        assertSeparatorEquals(grouped.get(0), 4, "A");
+    }
+
     /**
      * Match strings that are a substring of the specified String.
      */
@@ -1499,6 +1516,33 @@ public class SeparatorListTest {
         assertSeparatorEquals(separatorList.get(4), 1, new Element(2, 4));
     }
 
+    @Test
+    public void testSeparatorNotShifted()
+    {
+        TransactionList<Element> source = createLinearElementSource();
+        SeparatorList<Element> separatorList = new SeparatorList<Element>(source, elementComparator(), 0, Integer.MAX_VALUE);
+//        GroupingList<Element> separatorList = new GroupingList<Element>(source, elementComparator());
+
+        source.beginEvent();
+        source.set(0, new Element(3, 1));
+        source.set(1, new Element(1, 2));
+        source.set(2, new Element(1, 3));
+        source.set(3, new Element(1, 4));
+        source.set(4, new Element(1, 5));
+        source.set(5, new Element(1, 6));
+        source.set(6, new Element(3, 7));
+        source.set(7, new Element(1, 8));
+        source.set(8, new Element(1, 9));
+        source.set(9, new Element(3, 10));
+        source.set(10, new Element(1, 11));
+        source.set(11, new Element(1, 12));
+        source.commitEvent();
+        assertSeparatorEquals(separatorList.get(0), 9, new Element(1, 2));
+        assertSeparatorEquals(separatorList.get(10), 9, new Element(3, 1));
+        assertSeparatorEquals(separatorList.get(20), 5, new Element(4, 19));
+        assertSeparatorEquals(separatorList.get(26), 8, new Element(5, 23));
+    }
+
     private TransactionList<Element> createElementSource() {
         TransactionList<Element> source = new TransactionList<Element>(new BasicEventList<Element>());
         source.add(new Element(1, 1));
@@ -1525,6 +1569,42 @@ public class SeparatorListTest {
         source.add(new Element(2, 5));
         source.add(new Element(3, 6));
         source.add(new Element(3, 7));
+        return source;
+    }
+
+    private TransactionList<Element> createLinearElementSource() {
+        TransactionList<Element> source = new TransactionList<Element>(new BasicEventList<Element>());
+        source.add(new Element(0, 1));
+        source.add(new Element(2, 2));
+        source.add(new Element(2, 3));
+        source.add(new Element(2, 4));
+        source.add(new Element(2, 5));
+        source.add(new Element(2, 6));
+        source.add(new Element(2, 7));
+        source.add(new Element(2, 8));
+        source.add(new Element(2, 9));
+        source.add(new Element(2, 10));
+        source.add(new Element(2, 11));
+        source.add(new Element(2, 12));
+        source.add(new Element(3, 13));
+        source.add(new Element(3, 14));
+        source.add(new Element(3, 15));
+        source.add(new Element(3, 16));
+        source.add(new Element(3, 17));
+        source.add(new Element(3, 18));
+        source.add(new Element(4, 19));
+        source.add(new Element(4, 19));
+        source.add(new Element(4, 20));
+        source.add(new Element(4, 21));
+        source.add(new Element(4, 22));
+        source.add(new Element(5, 23));
+        source.add(new Element(5, 24));
+        source.add(new Element(5, 25));
+        source.add(new Element(5, 26));
+        source.add(new Element(5, 27));
+        source.add(new Element(5, 28));
+        source.add(new Element(5, 29));
+        source.add(new Element(5, 30));
         return source;
     }
 

--- a/core/src/test/java/ca/odell/glazedlists/SeparatorListTest.java
+++ b/core/src/test/java/ca/odell/glazedlists/SeparatorListTest.java
@@ -1133,6 +1133,36 @@ public class SeparatorListTest {
         assertSeparatorEquals(separatorList.get(9), 5, new Element(3, 3));
     }
 
+    @Test
+    public void testSortingBug() {
+        TransactionList<Element> source = createElementSource();
+        SeparatorList<Element> separatorList = new SeparatorList<Element>(source, elementComparator(), 0, Integer.MAX_VALUE);
+
+        source.beginEvent();
+        source.set(10, new Element(1, 11));
+        source.set(1, new Element(3, 2));
+        source.commitEvent();
+        assertSeparatorEquals(separatorList.get(0), 5, new Element(1, 1));
+        assertSeparatorEquals(separatorList.get(6), 2, new Element(2, 5));
+        assertSeparatorEquals(separatorList.get(9), 5, new Element(3, 2));
+    }
+
+    @Test
+    public void testSortingBug2() {
+        TransactionList<Element> source = createElementSource();
+        source.set(2, new Element(2, 3));
+        SeparatorList<Element> separatorList = new SeparatorList<Element>(source, elementComparator(), 0, Integer.MAX_VALUE);
+
+        source.beginEvent();
+        source.set(10, new Element(1, 11));
+        source.set(1, new Element(3, 2));
+        source.set(2, new Element(3, 3));
+        source.commitEvent();
+        assertSeparatorEquals(separatorList.get(0), 5, new Element(1, 1));
+        assertSeparatorEquals(separatorList.get(6), 2, new Element(2, 5));
+        assertSeparatorEquals(separatorList.get(9), 5, new Element(3, 2));
+    }
+
     private TransactionList<Element> createElementSource() {
         TransactionList<Element> source = new TransactionList<Element>(new BasicEventList<Element>());
         source.add(new Element(1, 1));

--- a/core/src/test/java/ca/odell/glazedlists/SeparatorListTest.java
+++ b/core/src/test/java/ca/odell/glazedlists/SeparatorListTest.java
@@ -1543,6 +1543,42 @@ public class SeparatorListTest {
         assertSeparatorEquals(separatorList.get(26), 8, new Element(5, 23));
     }
 
+    @Test
+    public void testLinearNewGroupCreation() {
+        TransactionList<Element> source = createLinearElementSource2();
+        SeparatorList<Element> separatorList = new SeparatorList<Element>(source, elementComparator(), 0, Integer.MAX_VALUE);
+
+        source.beginEvent();
+        source.set(1, new Element(2, 2));
+        source.set(2, new Element(2, 3));
+        source.set(3, new Element(2, 4));
+        source.set(4, new Element(2, 5));
+        source.set(5, new Element(2, 6));
+        source.set(6, new Element(2, 7));
+        source.commitEvent();
+        assertSeparatorEquals(separatorList.get(0), 1, new Element(1, 1));
+        assertSeparatorEquals(separatorList.get(2), 6, new Element(2, 2));
+        assertSeparatorEquals(separatorList.get(9), 10, new Element(3, 8));
+        assertSeparatorEquals(separatorList.get(20), 1, new Element(4, 18));
+    }
+
+    @Test
+    public void testLinearNewGroupCreation2() {
+        TransactionList<Element> source = createLinearElementSource2();
+        SeparatorList<Element> separatorList = new SeparatorList<Element>(source, elementComparator(), 0, Integer.MAX_VALUE);
+
+        source.beginEvent();
+        source.set(0, new Element(1, 1));
+        source.remove(1);
+        source.set(1, new Element(2, 3));
+        source.set(2, new Element(2, 4));
+        source.commitEvent();
+        assertSeparatorEquals(separatorList.get(0), 4, new Element(1, 1));
+        assertSeparatorEquals(separatorList.get(5), 2, new Element(2, 3));
+        assertSeparatorEquals(separatorList.get(8), 10, new Element(3, 8));
+        assertSeparatorEquals(separatorList.get(19), 1, new Element(4, 18));
+    }
+
     private TransactionList<Element> createElementSource() {
         TransactionList<Element> source = new TransactionList<Element>(new BasicEventList<Element>());
         source.add(new Element(1, 1));
@@ -1605,6 +1641,29 @@ public class SeparatorListTest {
         source.add(new Element(5, 28));
         source.add(new Element(5, 29));
         source.add(new Element(5, 30));
+        return source;
+    }
+
+    private TransactionList<Element> createLinearElementSource2() {
+        TransactionList<Element> source = new TransactionList<Element>(new BasicEventList<Element>());
+        source.add(new Element(1, 1));
+        source.add(new Element(1, 2));
+        source.add(new Element(1, 3));
+        source.add(new Element(1, 4));
+        source.add(new Element(1, 5));
+        source.add(new Element(1, 6));
+        source.add(new Element(1, 7));
+        source.add(new Element(3, 8));
+        source.add(new Element(3, 9));
+        source.add(new Element(3, 10));
+        source.add(new Element(3, 11));
+        source.add(new Element(3, 12));
+        source.add(new Element(3, 13));
+        source.add(new Element(3, 14));
+        source.add(new Element(3, 15));
+        source.add(new Element(3, 16));
+        source.add(new Element(3, 17));
+        source.add(new Element(4, 18));
         return source;
     }
 

--- a/core/src/test/java/ca/odell/glazedlists/SeparatorListTest.java
+++ b/core/src/test/java/ca/odell/glazedlists/SeparatorListTest.java
@@ -1104,4 +1104,97 @@ public class SeparatorListTest {
         assertEquals(1, separated.size());
         assertEquals(2, ((SeparatorList.Separator) separated.get(0)).size());
     }
+
+    @Test
+    public void testInsertBugFix() {
+        TransactionList<Element> source = createElementSource();
+        SeparatorList<Element> separatorList = new SeparatorList<Element>(source, elementComparator(), 0, Integer.MAX_VALUE);
+
+        source.beginEvent();
+        source.set(3, new Element(1, 4));
+        source.set(7, new Element(1, 8));
+        source.commitEvent();
+        assertSeparatorEquals(separatorList.get(0), 5, new Element(1, 1));
+        assertSeparatorEquals(separatorList.get(6), 3, new Element(2, 2));
+        assertSeparatorEquals(separatorList.get(10), 4, new Element(3, 3));
+    }
+
+    @Test
+    public void testDeleteBugFix() {
+        TransactionList<Element> source = createElementSource();
+        SeparatorList<Element> separatorList = new SeparatorList<Element>(source, elementComparator(), 0, Integer.MAX_VALUE);
+
+        source.beginEvent();
+        source.set(3, new Element(1, 4));
+        source.set(9, new Element(3, 10));
+        source.commitEvent();
+        assertSeparatorEquals(separatorList.get(0), 3, new Element(1, 1));
+        assertSeparatorEquals(separatorList.get(4), 4, new Element(2, 2));
+        assertSeparatorEquals(separatorList.get(9), 5, new Element(3, 3));
+    }
+
+    private TransactionList<Element> createElementSource() {
+        TransactionList<Element> source = new TransactionList<Element>(new BasicEventList<Element>());
+        source.add(new Element(1, 1));
+        source.add(new Element(2, 2));
+        source.add(new Element(3, 3));
+        source.add(new Element(1, 4));
+        source.add(new Element(2, 5));
+        source.add(new Element(3, 6));
+        source.add(new Element(1, 7));
+        source.add(new Element(2, 8));
+        source.add(new Element(3, 9));
+        source.add(new Element(1, 10));
+        source.add(new Element(2, 11));
+        source.add(new Element(3, 12));
+        return source;
+    }
+
+    private Comparator<Element> elementComparator() {
+        return new Comparator<Element>() {
+            @Override
+            public int compare(Element o1, Element o2) {
+                int x = o1.getGroup();
+                int y = o2.getGroup();
+                return (x < y) ? -1 : ((x == y) ? 0 : 1);
+            }
+        };
+    }
+
+    private class Element {
+        private final int group;
+        private final int id;
+
+        public Element(int group, int id) {
+            this.group = group;
+            this.id = id;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Element that = (Element) o;
+
+            return id == that.id;
+        }
+
+        @Override
+        public String toString() {
+            return "Element{" +
+                    "group=" + group +
+                    ", id=" + id +
+                    '}';
+        }
+
+        @Override
+        public int hashCode() {
+            return id;
+        }
+
+        public int getGroup() {
+            return group;
+        }
+    }
 }

--- a/core/src/test/java/ca/odell/glazedlists/SeparatorListTest.java
+++ b/core/src/test/java/ca/odell/glazedlists/SeparatorListTest.java
@@ -1468,6 +1468,22 @@ public class SeparatorListTest {
         assertSeparatorEquals(separatorList.get(7), 1, new Element(3, 7));
     }
 
+    @Test
+    public void testUpdateDeleteBug3() {
+        TransactionList<Element> source = createUpdateDeleteElementSource();
+        source.remove(6);
+        source.set(5, new Element(2, 6));
+        SeparatorList<Element> separatorList = new SeparatorList<Element>(source, elementComparator(), 0, Integer.MAX_VALUE);
+
+        source.beginEvent();
+        source.set(3, new Element(2, 4));
+        source.remove(5);
+        source.remove(4);
+        source.commitEvent();
+        assertSeparatorEquals(separatorList.get(0), 3, new Element(1, 1));
+        assertSeparatorEquals(separatorList.get(4), 1, new Element(2, 4));
+    }
+
     private TransactionList<Element> createElementSource() {
         TransactionList<Element> source = new TransactionList<Element>(new BasicEventList<Element>());
         source.add(new Element(1, 1));


### PR DESCRIPTION
There are many cases that cause the SeparatorList to get into a corrupt state, and crash with NullPointerExceptions and IndexOutOfBoundsExceptions.

Here I address many of these issues. Some of these are similar to recent fixes for GroupingList and UniqueList that did not sufficiently fix SeparatorList. More detail on the specific changes are documented in the commit messages, and the tests that reproduce these scenarios.

Even after these changes, I still have observed scenarios that cause the SeparatorList to get into a bad state. However, it is now far more stable than it was before.