### PR TITLE
Avoid specifying empty string for JVM args

### DIFF
--- a/extensions/swt/build.gradle
+++ b/extensions/swt/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 
 
 test {
-    jvmArgs osJvmArgs
+    if (!osJvmArgs.isEmpty()) jvmArgs osJvmArgs
 
     beforeSuite { descriptor ->
         // See https://github.com/glazedlists/glazedlists/issues/636


### PR DESCRIPTION
Specifying empty JVM args makes for some strange behavior, at least on
linux. In that case Gradle explodes with NoClassDefFoundErrors for its
security manager.