### PR TITLE
Update Gradle to 4.4.1 and enable build-cache and parallel execution

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,3 +7,5 @@ mavenStagingRepositoryId = oss-nexus-staging
 mavenStagingRepositoryUrl = https://oss.sonatype.org/service/local/staging/deploy/maven2
 sonatypeUsername = dummy
 sonatypePassword = dummyPassword
+org.gradle.parallel=true
+org.gradle.caching=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-bin.zip


### PR DESCRIPTION
Gradle 4.4.1 and parallel-execution reduces clean build-time from 2.5 minutes to 1 minute on my machine.

Enabling the build-cache bring down a build from clean to 14 seconds.