### PR TITLE
new build module: jmh-benchmark

### DIFF
--- a/benchmark.sh
+++ b/benchmark.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# benchmarks to include, regexp
+INCLUDE="BasicEventListBenchmark.testAdd"
+
+# overrides annotations for warmup-iteration, iterations and fork count
+CONFIG="-wi 5 -i 10 -f 1"
+
+# enabled stack profiler, show top 10 with 7 lines of stack
+PROFILERS=" -prof stack:lines=7;top=5"
+
+./gradlew jmh:capsule && java -jar jmh-benchmark/build/capsule/glazedlists-benchmarks.jar $INCLUDE $CONFIG $PROFILERS

--- a/jmh-benchmark/build.gradle
+++ b/jmh-benchmark/build.gradle
@@ -1,0 +1,27 @@
+apply plugin: 'us.kirchmeier.capsule'
+
+configurations {
+    apt
+}
+
+dependencies {
+    compile project(':core')
+    compile "org.openjdk.jmh:jmh-core:1.19"
+
+    apt "org.openjdk.jmh:jmh-generator-annprocess:1.19"
+}
+
+compileJava {
+    options.annotationProcessorPath = configurations.apt
+}
+
+task capsule(type: FatCapsule) {
+    destinationDir = file("$buildDir/capsule")
+    archiveName = "glazedlists-benchmarks.jar"
+    applicationClass 'ca.odell.glazedlists.BenchmarkMain'
+
+    capsuleManifest {
+        applicationId = 'ca.odell.glazedlists.BenchmarkMain'
+        minJavaVersion = '1.8.0'
+    }
+}

--- a/jmh-benchmark/src/main/java/ca.odell.glazedlists/BasicEventListBenchmark.java
+++ b/jmh-benchmark/src/main/java/ca.odell.glazedlists/BasicEventListBenchmark.java
@@ -1,0 +1,62 @@
+package ca.odell.glazedlists;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@State(Scope.Benchmark)
+public class BasicEventListBenchmark {
+
+    /**
+     * for remove test
+     */
+    private final BasicEventList<Integer> list = new BasicEventList<>();
+
+    public BasicEventListBenchmark() {
+        while (this.list.size() < 1000) {
+            this.list.add(this.list.size());
+        }
+    }
+
+    @Benchmark
+    @Warmup(iterations = 3)
+    @Measurement(iterations = 10)
+    @Fork(3)
+    public void testAdd() {
+        BasicEventList<Integer> list = new BasicEventList<>();
+
+        while (list.size() < 500) {
+            list.add(list.size());
+        }
+
+        while (list.size() < 1000) {
+            list.add(0, list.size());
+        }
+    }
+
+    @Benchmark
+    @Warmup(iterations = 3)
+    @Measurement(iterations = 10)
+    @Fork(3)
+    public void testRemove() {
+
+        while (list.size() < 500) {
+            list.add(list.size());
+        }
+
+        while (list.size() < 1000) {
+            list.add(0, list.size());
+        }
+
+        while (list.size() > 500) {
+            list.remove(0);
+        }
+
+        while (list.size() > 0) {
+            list.remove(list.size() - 1);
+        }
+    }
+}

--- a/jmh-benchmark/src/main/java/ca.odell.glazedlists/BenchmarkMain.java
+++ b/jmh-benchmark/src/main/java/ca.odell.glazedlists/BenchmarkMain.java
@@ -1,0 +1,17 @@
+package ca.odell.glazedlists;
+
+import java.io.IOException;
+
+import org.openjdk.jmh.Main;
+import org.openjdk.jmh.runner.RunnerException;
+
+public class BenchmarkMain {
+
+    public static void main(String[] args) {
+        try {
+            Main.main(args);
+        } catch (RunnerException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 rootProject.name = "glazedlists"
 
 include 'core'
+include 'jmh-benchmark'
 include 'extensions:calculation'
 include 'extensions:hibernate'
 include 'extensions:icu4j'


### PR DESCRIPTION
I've added a module with a Sample-JMH benchmark and a shellscript that compiles and starts the benchmarks automatically.

This follows the recommendation of creating a separate benchmark jar and start it in a fresh JVM.