### PR TITLE
Fixed ObservableElementList producing invalid change events

### DIFF
--- a/core/src/main/java/ca/odell/glazedlists/ObservableElementList.java
+++ b/core/src/main/java/ca/odell/glazedlists/ObservableElementList.java
@@ -423,8 +423,8 @@ public class ObservableElementList<E> extends TransformedList<E, E> implements O
             this.updates.beginEvent();
 
             // locate all indexes containing the given listElement
-            for (int i = 0, n = size(); i < n; i++) {
-            	final E currentElement = get(i);
+            for (int i = 0, n = this.observedElements.size(); i < n; i++) {
+            	final E currentElement = this.observedElements.get(i);
                 if (listElement == currentElement) {
                     this.updates.elementUpdated(i, currentElement);
                 }

--- a/core/src/test/java/ca/odell/glazedlists/ObservableElementListTest.java
+++ b/core/src/test/java/ca/odell/glazedlists/ObservableElementListTest.java
@@ -3,6 +3,8 @@
 /*                                                     O'Dell Engineering Ltd.*/
 package ca.odell.glazedlists;
 
+import ca.odell.glazedlists.event.ListEvent;
+import ca.odell.glazedlists.event.ListEventListener;
 import ca.odell.glazedlists.impl.beans.BeanConnector;
 import ca.odell.glazedlists.impl.testing.ListConsistencyListener;
 import ca.odell.glazedlists.matchers.Matcher;
@@ -367,6 +369,46 @@ public class ObservableElementListTest {
         for (Iterator<JLabel> i = list.iterator(); i.hasNext();) {
             assertEquals(list.get(0).getPropertyChangeListeners().length, i.next().getPropertyChangeListeners().length);
         }
+    }
+    
+    @Test
+    public void testUpdateFromListEvent() {
+        // should be correctly handling updates from previous listEventListeners
+        // inital list contains two elements
+        final EventList<JLabel> sourceList = new BasicEventList<JLabel>();
+        
+        // this is the bean we'll update in the listener.
+        final JLabel updatingLabel = new JLabel("Initial");
+        sourceList.add(updatingLabel);
+        // element modifying listener
+        ListEventListener<JLabel> sourceListModifier = new ListEventListener<JLabel>() {
+            @Override
+            public void listChanged(ListEvent<JLabel> listChanges) {
+                // perform the modification
+                updatingLabel.setText("Changed!");
+            }
+        };
+        sourceList.addListEventListener(sourceListModifier);
+
+        // the actual element observer
+        ObservableElementList<JLabel> observingList = new ObservableElementList<JLabel>(sourceList, GlazedLists.beanConnector(JLabel.class));
+
+        observingList.addListEventListener(new ListEventListener<JLabel>() {
+            @Override
+            public void listChanged(ListEvent<JLabel> listChanges) {
+                // the change we trigger later will insert one element at position 0, and the listener will update the last element (which now is at index 2)
+                while(listChanges.next()) {
+                    if(listChanges.getType() == ListEvent.UPDATE) {
+                        // the changed element should now be at index 2
+                        assertEquals(1, listChanges.getIndex());
+                    }
+                }
+            }
+        });
+
+        // we insert an element at position 0
+        // this will trigger a change in the updating element, and also shift that element by one
+        sourceList.add(0, new JLabel());
     }
 
     /**


### PR DESCRIPTION
I had a list structure where elements get modified by a ListEventListener, and an ObservableElementList listened for these changes. The ListEventPublisher is configured so the ObservableElementList's listChanged is executed later. However, the ListEvents produced by the ObservableElementList were invalid when elements got added to the source list.

The reason for this is the fact that when looking up the index of an updated element in elementUpdated, it would use this.get(), which delegates to the source list which already does contain the inserted elements, even though the insertion event is only processed later.

This pull request fixes this by looking up the elements in the local copy this.observedElements instead.

This is a continuation of #5, squashed and rebased to the current master branch.