### PR TITLE
Changes from review of #644

### DIFF
--- a/core/src/main/java/ca/odell/glazedlists/AbstractEventList.java
+++ b/core/src/main/java/ca/odell/glazedlists/AbstractEventList.java
@@ -121,9 +121,9 @@ public abstract class AbstractEventList<E> implements EventList<E> {
     @Override
     public boolean contains(Object object) {
         // for through this, looking for the lucky object
-	    for ( E e : this ) {
-		    if ( Objects.equals( object, e ) ) return true;
-	    }
+        for (E e : this) {
+            if (Objects.equals(object, e)) return true;
+        }
         // not found
         return false;
     }
@@ -158,10 +158,10 @@ public abstract class AbstractEventList<E> implements EventList<E> {
         // copy values into the array
         Object[] array = new Object[size()];
         int index = 0;
-	    for ( E e : this ) {
-		    array[ index ] = e;
-		    index++;
-	    }
+        for (E e : this) {
+            array[index] = e;
+            index++;
+        }
         return array;
     }
 
@@ -192,10 +192,10 @@ public abstract class AbstractEventList<E> implements EventList<E> {
 
         // copy values into the array
         int index = 0;
-	    for ( E e : this ) {
-		    array[ index ] = ( T ) e;
-		    index++;
-	    }
+        for (E e : this) {
+            array[index] = (T) e;
+            index++;
+        }
         return array;
     }
 
@@ -274,9 +274,9 @@ public abstract class AbstractEventList<E> implements EventList<E> {
     @Override
     public boolean containsAll(Collection<?> values) {
         // look for something that is missing
-	    for ( Object value : values ) {
-		    if ( !contains( value ) ) return false;
-	    }
+        for (Object value : values) {
+            if (!contains(value)) return false;
+        }
         // contained everything we looked for
         return true;
     }
@@ -564,9 +564,9 @@ public abstract class AbstractEventList<E> implements EventList<E> {
     @Override
     public int hashCode() {
         int hashCode = 1;
-	    for ( E a : this ) {
-		    hashCode = 31 * hashCode + ( a == null ? 0 : a.hashCode() );
-	    }
+        for (E a : this) {
+            hashCode = 31 * hashCode + (a == null ? 0 : a.hashCode());
+        }
         return hashCode;
     }
 
@@ -669,14 +669,13 @@ public abstract class AbstractEventList<E> implements EventList<E> {
     public int indexOf(Object object) {
         // for through this, looking for the lucky object
         int index = 0;
-	    for (E e : this) {
-		    if (Objects.equals(object, e)) {
-			    return index;
-		    }
-		    else {
-			    index++;
-		    }
-	    }
+        for (E e : this) {
+            if (Objects.equals(object, e)) {
+                return index;
+            } else {
+                index++;
+            }
+        }
         // not found
         return -1;
     }

--- a/core/src/main/java/ca/odell/glazedlists/AbstractEventList.java
+++ b/core/src/main/java/ca/odell/glazedlists/AbstractEventList.java
@@ -487,11 +487,11 @@ public abstract class AbstractEventList<E> implements EventList<E> {
     public void replaceAll(UnaryOperator<E> operator) {
         updates.beginEvent(true);                           // nested due to set below
         for (int i = size() - 1; i >= 0; i--) {
-            E old_value = get(i);
-            E new_value = operator.apply(old_value);
-            if (old_value != new_value) {                   // instance check
+            E oldValue = get(i);
+            E newValue = operator.apply(oldValue);
+            if (oldValue != newValue) {                   // instance check
                 try {
-                    set(i, new_value);
+                    set(i, newValue);
                 }
                 catch(UnsupportedOperationException ex) {
                     // Since the default implementation doesn't implement set(),
@@ -499,7 +499,7 @@ public abstract class AbstractEventList<E> implements EventList<E> {
                     updates.discardEvent();
                     throw ex;
                 }
-                updates.elementUpdated(i, old_value, new_value);
+                updates.elementUpdated(i, oldValue, newValue);
             }
         }
         updates.commitEvent();

--- a/core/src/main/java/ca/odell/glazedlists/AbstractEventList.java
+++ b/core/src/main/java/ca/odell/glazedlists/AbstractEventList.java
@@ -349,7 +349,15 @@ public abstract class AbstractEventList<E> implements EventList<E> {
 
         updates.beginEvent(true);
         for (E value : values) {
-            this.add(index, value);
+            try {
+                this.add(index, value);
+            }
+            catch(UnsupportedOperationException ex) {
+                // Since the default implementation doesn't implement add(),
+                // deal with that error to ensure the event isn't left dangling.
+                updates.discardEvent();
+                throw ex;
+            }
 
             // advance the insertion location if its within the size of the list
             if (index < this.size()) {

--- a/core/src/main/java/ca/odell/glazedlists/BasicEventList.java
+++ b/core/src/main/java/ca/odell/glazedlists/BasicEventList.java
@@ -253,11 +253,11 @@ public final class BasicEventList<E> extends AbstractEventList<E> implements Ser
     public void replaceAll(UnaryOperator<E> operator) {
         updates.beginEvent();
         for (int i = size() - 1; i >= 0; i--) {
-            E old_value = data.get(i);
-            E new_value = operator.apply(old_value);
-            if (old_value != new_value) {               // instance check
-                data.set(i, new_value);
-                updates.elementUpdated(i, old_value, new_value);
+            E oldValue = data.get(i);
+            E newValue = operator.apply(oldValue);
+            if (oldValue != newValue) {               // instance check
+                data.set(i, newValue);
+                updates.elementUpdated(i, oldValue, newValue);
             }
         }
         updates.commitEvent();

--- a/core/src/main/java/ca/odell/glazedlists/FunctionList.java
+++ b/core/src/main/java/ca/odell/glazedlists/FunctionList.java
@@ -350,7 +350,7 @@ public final class FunctionList<S, E> extends TransformedList<S, E> implements R
     public boolean removeIf(Predicate<? super E> filter) {
         // Ideally this remove would be processed as a single transaction. The only real
         // way that can happen (efficiently) is to get access to the source
-        // ListEventAssembler, which we can if the list extends AbstractEventList.
+        // ListEventAssembler, which is available if the list extends AbstractEventList.
         // Otherwise, things will work fine, but there will be multiple events dispatched
         // for a single remove operation.
         ListEventAssembler<?> sourceUpdates;
@@ -360,7 +360,7 @@ public final class FunctionList<S, E> extends TransformedList<S, E> implements R
         else sourceUpdates = null;
 
         boolean foundMatch = false;
-        for(int i = size() - 1; i >= 0; i--) {
+        for (int i = size() - 1; i >= 0; i--) {
             if (filter.test(mappedElements.get(i))) {
                 if (sourceUpdates != null && !foundMatch) {
                     sourceUpdates.beginEvent(true);

--- a/core/src/main/java/ca/odell/glazedlists/TransformedList.java
+++ b/core/src/main/java/ca/odell/glazedlists/TransformedList.java
@@ -90,18 +90,6 @@ public abstract class TransformedList<S, E> extends AbstractEventList<E> impleme
 
     /** {@inheritDoc} */
     @Override
-    public void clear() {
-        // nest changes and let the other methods compose the event
-        updates.beginEvent(true);
-        try {
-            super.clear();
-        } finally {
-            updates.commitEvent();
-        }
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public E get(int index) {
         if(index < 0 || index >= size()) throw new IndexOutOfBoundsException("Cannot get at " + index + " on list of size " + size());
         return (E) source.get(getSourceIndex(index));

--- a/core/src/main/java/ca/odell/glazedlists/TransformedList.java
+++ b/core/src/main/java/ca/odell/glazedlists/TransformedList.java
@@ -78,18 +78,6 @@ public abstract class TransformedList<S, E> extends AbstractEventList<E> impleme
 
     /** {@inheritDoc} */
     @Override
-    public boolean addAll(int index, Collection<? extends E> values) {
-        // nest changes and let the other methods compose the event
-        updates.beginEvent(true);
-        try {
-            return super.addAll(index, values);
-        } finally {
-            updates.commitEvent();
-        }
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public E get(int index) {
         if(index < 0 || index >= size()) throw new IndexOutOfBoundsException("Cannot get at " + index + " on list of size " + size());
         return (E) source.get(getSourceIndex(index));
@@ -101,30 +89,6 @@ public abstract class TransformedList<S, E> extends AbstractEventList<E> impleme
         if(!isWritable()) throw new IllegalStateException("Non-writable List cannot be modified");
         if(index < 0 || index >= size()) throw new IndexOutOfBoundsException("Cannot remove at " + index + " on list of size " + size());
         return (E) source.remove(getSourceIndex(index));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public boolean removeAll(Collection<?> collection) {
-        // nest changes and let the other methods compose the event
-        updates.beginEvent(true);
-        try {
-            return super.removeAll(collection);
-        } finally {
-            updates.commitEvent();
-        }
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public boolean retainAll(Collection<?> values) {
-        // nest changes and let the other methods compose the event
-        updates.beginEvent(true);
-        try {
-            return super.retainAll(values);
-        } finally {
-            updates.commitEvent();
-        }
     }
 
     /** {@inheritDoc} */

--- a/core/src/main/java/ca/odell/glazedlists/impl/FunctionListMap.java
+++ b/core/src/main/java/ca/odell/glazedlists/impl/FunctionListMap.java
@@ -145,13 +145,14 @@ public class FunctionListMap<K, V> implements DisposableMap<K, V> {
     }
 
     private V putNoAgreementCheck(K key, V value) {
-        final V toReplace = get(key);
 
         // if no prior value exists for this key, simply add it
-        if (toReplace == null) {
+        if (!containsKey(key)) {
             valueList.add(value);
             return null;
         }
+
+        final V toReplace = get(key);
 
         if (!replaceValue(toReplace, value)) {
             // something terrible has happened if a value exists in the delegate Map but

--- a/core/src/main/java/ca/odell/glazedlists/impl/FunctionListMap.java
+++ b/core/src/main/java/ca/odell/glazedlists/impl/FunctionListMap.java
@@ -168,9 +168,9 @@ public class FunctionListMap<K, V> implements DisposableMap<K, V> {
         // Try to work sequentially since there is no cost to this approach.
         if (valueList instanceof RandomAccess) {
             for (int i = valueList.size() - 1; i >= 0; i--) {
-                V index_value = valueList.get(i);
+                V indexValue = valueList.get(i);
                 //noinspection ObjectEquality
-                if (index_value == replaceInstance) {
+                if (indexValue == replaceInstance) {
                     valueList.set(i, newValue);
                     return true;
                 }

--- a/core/src/test/java/ca/odell/glazedlists/AbstractEventListTest.java
+++ b/core/src/test/java/ca/odell/glazedlists/AbstractEventListTest.java
@@ -3,6 +3,8 @@ package ca.odell.glazedlists;
 import ca.odell.glazedlists.event.ListEventAssembler;
 import org.junit.Test;
 
+import java.util.Arrays;
+
 import static org.junit.Assert.*;
 
 /**
@@ -14,7 +16,7 @@ public class AbstractEventListTest {
     // destroy assembler state
     @Test
     public void replaceAll_unimplementedSet() {
-        AbstractEventList<String> my_list = new AbstractEventList<String>() {
+        AbstractEventList<String> list = new AbstractEventList<String>() {
             @Override
             public int size() {
                 return 1;
@@ -29,16 +31,48 @@ public class AbstractEventListTest {
             @Override
             public void dispose() {}
         };
-        assertFalse(my_list.updates.isEventInProgress());
+        assertFalse(list.updates.isEventInProgress());
 
         try {
-            my_list.replaceAll(s -> "Not gonna work");
+            list.replaceAll(s -> "Not gonna work");
             fail("Shouldn't have worked");
         }
         catch(UnsupportedOperationException ex) {
             // expected
         }
 
-        assertFalse(my_list.updates.isEventInProgress());
+        assertFalse(list.updates.isEventInProgress());
+    }
+
+    // Ensure calling addAll on a list with an unimplemented add() doesn't completely
+    // destroy assembler state
+    @Test
+    public void addAll_unimplementedSet() {
+        AbstractEventList<String> list = new AbstractEventList<String>() {
+            @Override
+            public int size() {
+                return 1;
+            }
+
+            @Override
+            public String get(int index) {
+                if (index != 0) throw new IndexOutOfBoundsException("Wha??");
+                return "Zero";
+            }
+
+            @Override
+            public void dispose() {}
+        };
+        assertFalse(list.updates.isEventInProgress());
+
+        try {
+            list.addAll(Arrays.asList("Not","gonna","work"));
+            fail("Shouldn't have worked");
+        }
+        catch(UnsupportedOperationException ex) {
+            // expected
+        }
+
+        assertFalse(list.updates.isEventInProgress());
     }
 }

--- a/core/src/test/java/ca/odell/glazedlists/impl/FunctionListMapTest.java
+++ b/core/src/test/java/ca/odell/glazedlists/impl/FunctionListMapTest.java
@@ -829,6 +829,32 @@ public class FunctionListMapTest {
         eventMap.dispose();
     }
 
+    @Test
+    public void testPutNull() {
+        final EventList<String> source = new BasicEventList<String>();
+        source.add("Jesse");
+        source.add(null);
+        source.add("Katie");
+        final Map<String, String> eventMap = GlazedLists.syncEventListToMap(source, new FirstLetterOrNullFunction());
+        assertEquals(3, eventMap.size());
+        assertEquals("Jesse", eventMap.get("J"));
+        assertEquals("Katie", eventMap.get("K"));
+        assertEquals(null, eventMap.get("UNKNOWN"));
+        assertEquals(null, eventMap.put("UNKNOWN", null));
+        assertEquals(3, eventMap.size());
+        assertEquals("Jesse", eventMap.get("J"));
+        assertEquals("Katie", eventMap.get("K"));
+        assertEquals(null, eventMap.get("UNKNOWN"));
+    }
+
+    private static final class FirstLetterOrNullFunction implements FunctionList.Function<String, String> {
+        @Override
+        public String evaluate(String sourceValue) {
+            return sourceValue == null ? "UNKNOWN" : String.valueOf(sourceValue.charAt(0));
+        }
+    }
+
+
     private static final class FirstLetterComparator implements Comparator<String> {
         @Override
         public int compare(String o1, String o2) {


### PR DESCRIPTION
The clear implementation in TransformedList was no longer necessary due
to recent work in AbstractEventList.

Re-implement removeIf in AbstractEventList. It's almost exactly the same
as the default implementation in Collection but adds a batch event
wrapper.

Related to the above, a batch event wrapper was added to the addAll
method.

As was done with replaceAll, handle UnsupportedOperationException
when calling addAll with an unimplemented add() on a list so it doesn't
destroy the ListEventAssembler.

Correct snake_case variable names.

Relates to: #644