### PR TITLE
Proper getOldValue/getNewValue implementation without breaking API

### DIFF
--- a/core/src/main/java/ca/odell/glazedlists/event/ListEvent.java
+++ b/core/src/main/java/ca/odell/glazedlists/event/ListEvent.java
@@ -8,6 +8,7 @@ import ca.odell.glazedlists.SortedList;
 import ca.odell.glazedlists.TransformedList;
 
 import java.util.EventObject;
+import java.util.List;
 
 /**
  * A ListEvent models a sequence of changes to an {@link EventList}. A
@@ -326,24 +327,16 @@ public abstract class ListEvent<E> extends EventObject {
     /**
      * Gets the previous value for a deleted or updated element. If that data is
      * not available, this will return {@link ListEvent#UNKNOWN_VALUE}.
-     *
-     * @deprecated this is a <strong>developer preview</strong> API that is not
-     * yet fit for human consumption. Hopefully the full implementation is
-     * complete for Glazed Lists 2.0.
      */
-    @Deprecated
     public abstract E getOldValue();
 
     /**
      * Gets the current value for an inserted or updated element. If that data is
      * not available, this will return {@link ListEvent#UNKNOWN_VALUE}.
-     *
-     * @deprecated this is a <strong>developer preview</strong> API that is not
-     * yet fit for human consumption. Hopefully the full implementation is
-     * complete for Glazed Lists 2.0.
      */
-    @Deprecated
     public abstract E getNewValue();
+
+    public abstract List<ObjectChange<E>> getBlockChanges();
 
     /**
      * Gets the number of blocks currently remaining in this atomic change.

--- a/core/src/main/java/ca/odell/glazedlists/event/ListEventAssembler.java
+++ b/core/src/main/java/ca/odell/glazedlists/event/ListEventAssembler.java
@@ -143,8 +143,7 @@ public final class ListEventAssembler<E> {
     public void elementDeleted(int index, E oldValue) {
         addChange(ListEvent.DELETE, index,  ObjectChange.create(oldValue, ListEvent.unknownValue()));
     }
-
-
+    
     /**
      * @deprecated replaced with {@link #elementUpdated(int, Object, Object)}.
      */

--- a/core/src/main/java/ca/odell/glazedlists/event/ListEventAssembler.java
+++ b/core/src/main/java/ca/odell/glazedlists/event/ListEventAssembler.java
@@ -143,7 +143,7 @@ public final class ListEventAssembler<E> {
     public void elementDeleted(int index, E oldValue) {
         addChange(ListEvent.DELETE, index,  ObjectChange.create(oldValue, ListEvent.unknownValue()));
     }
-    
+
     /**
      * @deprecated replaced with {@link #elementUpdated(int, Object, Object)}.
      */

--- a/core/src/main/java/ca/odell/glazedlists/event/ObjectChange.java
+++ b/core/src/main/java/ca/odell/glazedlists/event/ObjectChange.java
@@ -1,0 +1,160 @@
+package ca.odell.glazedlists.event;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public class ObjectChange<T> {
+    private static final ObjectChange<Object> UNKNOWN_CHANGE = new ObjectChange<>(ListEvent.UNKNOWN_VALUE, ListEvent.UNKNOWN_VALUE);
+
+    private final T oldValue;
+    private final T newValue;
+
+    private ObjectChange(T oldValue, T newValue) {
+        this.oldValue = oldValue;
+        this.newValue = newValue;
+    }
+
+    public T getOldValue() {
+        return oldValue;
+    }
+
+    public T getNewValue() {
+        return newValue;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ObjectChange<?> that = (ObjectChange<?>) o;
+        return Objects.equals(oldValue, that.oldValue) &&
+                Objects.equals(newValue, that.newValue);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(oldValue, newValue);
+    }
+
+    @Override
+    public String toString() {
+        return "ObjectChange{" +
+                "oldValue=" + oldValue +
+                ", newValue=" + newValue +
+                '}';
+    }
+
+    public static <E> Object flat(ObjectChange<E> event){
+        if(event.getOldValue() == ListEvent.UNKNOWN_VALUE && event.getNewValue() == ListEvent.UNKNOWN_VALUE){
+            return ListEvent.UNKNOWN_VALUE;
+        }else if(event.getOldValue() != ListEvent.UNKNOWN_VALUE && event.getNewValue() != ListEvent.UNKNOWN_VALUE){
+            return event;
+        }else if(event.getNewValue() != ListEvent.UNKNOWN_VALUE){
+            return event.getNewValue();
+        }else {
+            return event.getOldValue();
+        }
+    }
+
+    public static <E> void flat(List<ObjectChange<E>> events, List<Object> target){
+        for(int i = 0; i<events.size(); i++){
+            target.add(ObjectChange.flat(events.get(i)));
+        }
+    }
+
+    public static <E> E getValue(Object element, int changeType){
+        if(changeType == ListEvent.INSERT){
+            return getNewValue(element, changeType);
+        }else {
+            return getOldValue(element, changeType);
+        }
+    }
+
+    public static <E> E getNewValue(Object element, int changeType){
+        if(changeType == ListEvent.INSERT){
+            return (E)element;
+        }else if(changeType == ListEvent.DELETE){
+            return ListEvent.<E>unknownValue();
+        }else if(changeType == ListEvent.UPDATE) {
+            final ObjectChange<E> event = (ObjectChange<E>)element;
+            return event.getNewValue();
+        }else{
+            return ListEvent.<E>unknownValue();
+        }
+    }
+
+    public static <E> E getOldValue(Object element, int changeType){
+        if(changeType == ListEvent.INSERT){
+            return ListEvent.<E>unknownValue();
+        }else if(changeType == ListEvent.DELETE){
+            return (E)element;
+        }else if(changeType == ListEvent.UPDATE) {
+            final ObjectChange<E> event = (ObjectChange<E>)element;
+            return event.getOldValue();
+        }else {
+            return ListEvent.<E>unknownValue();
+        }
+    }
+
+    public static <E> Object createElement(E oldValue, E newValue){
+        if(oldValue == ListEvent.UNKNOWN_VALUE && newValue == ListEvent.UNKNOWN_VALUE){
+            return ObjectChange.unknownChange();
+        }else if(oldValue != ListEvent.UNKNOWN_VALUE && newValue != ListEvent.UNKNOWN_VALUE){
+            return ObjectChange.create(oldValue, newValue);
+        }else if(newValue != ListEvent.UNKNOWN_VALUE){
+            return newValue;
+        }else {
+            return oldValue;
+        }
+    }
+
+    public static <E> ObjectChange<E> create(E oldValue, E newValue){
+        if(oldValue == ListEvent.UNKNOWN_VALUE && newValue == ListEvent.UNKNOWN_VALUE){
+            return unknownChange();
+        }else{
+            return new ObjectChange<>(oldValue, newValue);
+        }
+    }
+
+    public static <E> List<E> getNewValues(List<ObjectChange<E>> events){
+        final List<E> newValues = new ArrayList<>(events.size());
+        for(int i = 0; i<events.size(); i++){
+            newValues.add(events.get(i).getNewValue());
+        }
+        return newValues;
+    }
+
+    public static <E> List<E> getOldValues(List<Object> events, int changeType){
+        final List<E> list = new ArrayList<>(events.size());
+        for(int i = 0; i<events.size(); i++){
+            list.add(getOldValue(events.get(i), changeType));
+        }
+        return list;
+    }
+
+    public static <E> List<E> getNewValues(List<Object> events, int changeType){
+        final List<E> list = new ArrayList<>(events.size());
+        for(int i = 0; i<events.size(); i++){
+            list.add(getNewValue(events.get(i), changeType));
+        }
+        return list;
+    }
+
+    public static <E> List<E> getOldValues(List<ObjectChange<E>> events){
+        final List<E> oldValues = new ArrayList<>(events.size());
+        for(int i = 0; i<events.size(); i++){
+            oldValues.add(events.get(i).getOldValue());
+        }
+        return oldValues;
+    }
+
+    public static <E> ObjectChange<E> unknownChange(){
+        return (ObjectChange<E>)UNKNOWN_CHANGE;
+    }
+
+    public static <E> List<ObjectChange<E>> unknownChange(int size){
+        return Collections.nCopies(size, unknownChange());
+    }
+}

--- a/core/src/main/java/ca/odell/glazedlists/event/ObjectChange.java
+++ b/core/src/main/java/ca/odell/glazedlists/event/ObjectChange.java
@@ -46,70 +46,6 @@ public class ObjectChange<T> {
                 '}';
     }
 
-    public static <E> Object flat(ObjectChange<E> event){
-        if(event.getOldValue() == ListEvent.UNKNOWN_VALUE && event.getNewValue() == ListEvent.UNKNOWN_VALUE){
-            return ListEvent.UNKNOWN_VALUE;
-        }else if(event.getOldValue() != ListEvent.UNKNOWN_VALUE && event.getNewValue() != ListEvent.UNKNOWN_VALUE){
-            return event;
-        }else if(event.getNewValue() != ListEvent.UNKNOWN_VALUE){
-            return event.getNewValue();
-        }else {
-            return event.getOldValue();
-        }
-    }
-
-    public static <E> void flat(List<ObjectChange<E>> events, List<Object> target){
-        for(int i = 0; i<events.size(); i++){
-            target.add(ObjectChange.flat(events.get(i)));
-        }
-    }
-
-    public static <E> E getValue(Object element, int changeType){
-        if(changeType == ListEvent.INSERT){
-            return getNewValue(element, changeType);
-        }else {
-            return getOldValue(element, changeType);
-        }
-    }
-
-    public static <E> E getNewValue(Object element, int changeType){
-        if(changeType == ListEvent.INSERT){
-            return (E)element;
-        }else if(changeType == ListEvent.DELETE){
-            return ListEvent.<E>unknownValue();
-        }else if(changeType == ListEvent.UPDATE) {
-            final ObjectChange<E> event = (ObjectChange<E>)element;
-            return event.getNewValue();
-        }else{
-            return ListEvent.<E>unknownValue();
-        }
-    }
-
-    public static <E> E getOldValue(Object element, int changeType){
-        if(changeType == ListEvent.INSERT){
-            return ListEvent.<E>unknownValue();
-        }else if(changeType == ListEvent.DELETE){
-            return (E)element;
-        }else if(changeType == ListEvent.UPDATE) {
-            final ObjectChange<E> event = (ObjectChange<E>)element;
-            return event.getOldValue();
-        }else {
-            return ListEvent.<E>unknownValue();
-        }
-    }
-
-    public static <E> Object createElement(E oldValue, E newValue){
-        if(oldValue == ListEvent.UNKNOWN_VALUE && newValue == ListEvent.UNKNOWN_VALUE){
-            return ObjectChange.unknownChange();
-        }else if(oldValue != ListEvent.UNKNOWN_VALUE && newValue != ListEvent.UNKNOWN_VALUE){
-            return ObjectChange.create(oldValue, newValue);
-        }else if(newValue != ListEvent.UNKNOWN_VALUE){
-            return newValue;
-        }else {
-            return oldValue;
-        }
-    }
-
     public static <E> ObjectChange<E> create(E oldValue, E newValue){
         if(oldValue == ListEvent.UNKNOWN_VALUE && newValue == ListEvent.UNKNOWN_VALUE){
             return unknownChange();
@@ -118,36 +54,12 @@ public class ObjectChange<T> {
         }
     }
 
-    public static <E> List<E> getNewValues(List<ObjectChange<E>> events){
-        final List<E> newValues = new ArrayList<>(events.size());
-        for(int i = 0; i<events.size(); i++){
-            newValues.add(events.get(i).getNewValue());
-        }
-        return newValues;
+    public static <E> List<ObjectChange<E>> create(int size, E oldValue, E newValue){
+        return create(size, create(oldValue, newValue));
     }
 
-    public static <E> List<E> getOldValues(List<Object> events, int changeType){
-        final List<E> list = new ArrayList<>(events.size());
-        for(int i = 0; i<events.size(); i++){
-            list.add(getOldValue(events.get(i), changeType));
-        }
-        return list;
-    }
-
-    public static <E> List<E> getNewValues(List<Object> events, int changeType){
-        final List<E> list = new ArrayList<>(events.size());
-        for(int i = 0; i<events.size(); i++){
-            list.add(getNewValue(events.get(i), changeType));
-        }
-        return list;
-    }
-
-    public static <E> List<E> getOldValues(List<ObjectChange<E>> events){
-        final List<E> oldValues = new ArrayList<>(events.size());
-        for(int i = 0; i<events.size(); i++){
-            oldValues.add(events.get(i).getOldValue());
-        }
-        return oldValues;
+    public static <E> List<ObjectChange<E>> create(int size, ObjectChange<E> change){
+        return Collections.nCopies(size, change);
     }
 
     public static <E> ObjectChange<E> unknownChange(){

--- a/core/src/main/java/ca/odell/glazedlists/event/Tree4DeltasListEvent.java
+++ b/core/src/main/java/ca/odell/glazedlists/event/Tree4DeltasListEvent.java
@@ -7,6 +7,8 @@ import ca.odell.glazedlists.EventList;
 import ca.odell.glazedlists.impl.event.BlockSequence;
 import ca.odell.glazedlists.impl.event.Tree4Deltas;
 
+import java.util.List;
+
 /**
  * A list event that iterates {@link Tree4Deltas} as the
  * datastore.
@@ -90,7 +92,7 @@ class Tree4DeltasListEvent<E> extends ListEvent<E> {
     @Override
     public int getBlockStartIndex() {
         if(linearIterator != null) return linearIterator.getBlockStart();
-        else return deltasIterator.getIndex();
+        else return deltasIterator.getStartIndex();
     }
 
     @Override
@@ -119,8 +121,20 @@ class Tree4DeltasListEvent<E> extends ListEvent<E> {
 
     @Override
     public E getNewValue() {
-        // TODO(jessewilson):
-        return ListEvent.<E>unknownValue();
+        if(linearIterator != null) {
+            return (E)linearIterator.getNewValue();
+        } else {
+            return (E)deltasIterator.getNewValue();
+        }
+    }
+
+    @Override
+    public List<ObjectChange<E>> getBlockChanges() {
+        if(linearIterator != null) {
+            return (List<ObjectChange<E>>)linearIterator.getBlockChanges();
+        } else {
+            return (List<ObjectChange<E>>)deltasIterator.getBlockChanges();
+        }
     }
 
     @Override

--- a/core/src/main/java/ca/odell/glazedlists/impl/event/BlockSequence.java
+++ b/core/src/main/java/ca/odell/glazedlists/impl/event/BlockSequence.java
@@ -31,8 +31,7 @@ public class BlockSequence<E> {
      * @param endIndex the last index, exclusive
      */
     public boolean update(int startIndex, int endIndex) {
-        return this.addChange(startIndex, ListEvent.UPDATE, Collections.nCopies(endIndex-startIndex, ObjectChange
-                .unknownChange()));
+        return this.addChange(startIndex, ListEvent.UPDATE, ObjectChange.unknownChange(endIndex-startIndex));
     }
 
     /**
@@ -40,8 +39,7 @@ public class BlockSequence<E> {
      * @param endIndex the last index, exclusive
      */
     public boolean insert(int startIndex, int endIndex) {
-        return this.addChange(startIndex, ListEvent.INSERT, Collections.nCopies(endIndex-startIndex, ObjectChange
-                .unknownChange()));
+        return this.addChange(startIndex, ListEvent.INSERT, ObjectChange.unknownChange(endIndex-startIndex));
     }
 
     /**
@@ -49,8 +47,7 @@ public class BlockSequence<E> {
      * @param endIndex the last index, exclusive
      */
     public boolean delete(int startIndex, int endIndex) {
-        return this.addChange(startIndex, ListEvent.DELETE, Collections.nCopies(endIndex-startIndex, ObjectChange
-                .unknownChange()));
+        return this.addChange(startIndex, ListEvent.DELETE, ObjectChange.unknownChange(endIndex-startIndex));
     }
 
     /**
@@ -63,8 +60,7 @@ public class BlockSequence<E> {
      */
     @Deprecated
     public boolean addChange(int type, int startIndex, int endIndex, E oldValue, E newValue) {
-        return this.addChange(startIndex, type, Collections.nCopies(endIndex-startIndex, ObjectChange.create(oldValue,
-                newValue)));
+        return this.addChange(startIndex, type, ObjectChange.create(endIndex-startIndex, oldValue, newValue));
     }
 
     public boolean addChange(int startIndex, int changeType, List<ObjectChange<E>> events) {

--- a/core/src/main/java/ca/odell/glazedlists/impl/event/Tree4Deltas.java
+++ b/core/src/main/java/ca/odell/glazedlists/impl/event/Tree4Deltas.java
@@ -134,8 +134,7 @@ public class Tree4Deltas<E> {
      */
     @Deprecated
     public void targetUpdate(int startIndex, int endIndex, E oldValue, E newValue) {
-        this.addTargetChange(startIndex, ListEvent.UPDATE, Collections.nCopies(endIndex - startIndex, ObjectChange.create
-                (oldValue, newValue)));
+        this.addTargetChange(startIndex, ListEvent.UPDATE, ObjectChange.create(endIndex - startIndex, oldValue, newValue));
     }
 
     /**
@@ -152,8 +151,7 @@ public class Tree4Deltas<E> {
      */
     @Deprecated
     public void targetInsert(int startIndex, int endIndex, E newValue) {
-        this.addTargetChange(startIndex, ListEvent.INSERT, Collections.nCopies(endIndex - startIndex, ObjectChange.create
-                (ListEvent.unknownValue(), newValue)));
+        this.addTargetChange(startIndex, ListEvent.INSERT, ObjectChange.create(endIndex - startIndex, ListEvent.unknownValue(), newValue));
     }
 
     /**
@@ -168,8 +166,7 @@ public class Tree4Deltas<E> {
      */
     @Deprecated
     public void targetDelete(int startIndex, int endIndex, E value) {
-        this.addTargetChange(startIndex, ListEvent.DELETE, Collections.nCopies(endIndex - startIndex, ObjectChange.create
-                (value, ListEvent.unknownValue())));
+        this.addTargetChange(startIndex, ListEvent.DELETE, ObjectChange.create(endIndex - startIndex, value, ListEvent.unknownValue()));
     }
 
     public void sourceInsert(int sourceIndex) {
@@ -342,7 +339,7 @@ public class Tree4Deltas<E> {
             final Element<ObjectChange<E>> node = treeIterator.node();
             final int size = treeIterator.nodeSize(ALL_INDICES);
             if (size == 1) return Collections.singletonList(node.get());
-            return Collections.nCopies(size, node.get());
+            return ObjectChange.create(size, node.get());
         }
     }
 }

--- a/core/src/main/java/ca/odell/glazedlists/impl/event/Tree4Deltas.java
+++ b/core/src/main/java/ca/odell/glazedlists/impl/event/Tree4Deltas.java
@@ -3,13 +3,16 @@
 /*                                                     O'Dell Engineering Ltd.*/
 package ca.odell.glazedlists.impl.event;
 
-import java.util.Arrays;
-
 import ca.odell.glazedlists.event.ListEvent;
+import ca.odell.glazedlists.event.ObjectChange;
 import ca.odell.glazedlists.impl.adt.barcode2.Element;
 import ca.odell.glazedlists.impl.adt.barcode2.FourColorTree;
 import ca.odell.glazedlists.impl.adt.barcode2.FourColorTreeIterator;
 import ca.odell.glazedlists.impl.adt.barcode2.ListToByteCoder;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Manage and describe the differences between two revisions of the
@@ -23,7 +26,9 @@ import ca.odell.glazedlists.impl.adt.barcode2.ListToByteCoder;
  */
 public class Tree4Deltas<E> {
 
-    /** all the names of the index sets are with respect to the target */
+    /**
+     * all the names of the index sets are with respect to the target
+     */
     private static final ListToByteCoder<String> BYTE_CODER = new ListToByteCoder<>(Arrays.asList("+", "U", "X", "_"));
     public static final byte INSERT = BYTE_CODER.colorToByte("+");
     public static final byte UPDATE = BYTE_CODER.colorToByte("U");
@@ -35,8 +40,10 @@ public class Tree4Deltas<E> {
     private static final byte ALL_INDICES = BYTE_CODER.colorsToByte(Arrays.asList("U", "X", "+", "_"));
     private static final byte CHANGE_INDICES = BYTE_CODER.colorsToByte(Arrays.asList("U", "X", "+"));
 
-    /** the trees values include removed elements */
-    private FourColorTree<E> tree = new FourColorTree<>(BYTE_CODER);
+    /**
+     * the trees values include removed elements
+     */
+    private FourColorTree<ObjectChange<E>> tree = new FourColorTree<>(BYTE_CODER);
     private boolean allowContradictingEvents = false;
 
     /**
@@ -51,53 +58,84 @@ public class Tree4Deltas<E> {
     public boolean getAllowContradictingEvents() {
         return allowContradictingEvents;
     }
+
     public void setAllowContradictingEvents(boolean allowContradictingEvents) {
         this.allowContradictingEvents = allowContradictingEvents;
     }
 
     public int targetToSource(int targetIndex) {
-        if(!initialCapacityKnown) ensureCapacity(targetIndex + 1);
+        if (!initialCapacityKnown) ensureCapacity(targetIndex + 1);
         return tree.convertIndexColor(targetIndex, TARGET_INDICES, SOURCE_INDICES);
     }
 
     public int sourceToTarget(int sourceIndex) {
-        if(!initialCapacityKnown) ensureCapacity(sourceIndex + 1);
+        if (!initialCapacityKnown) ensureCapacity(sourceIndex + 1);
         return tree.convertIndexColor(sourceIndex, SOURCE_INDICES, TARGET_INDICES);
+    }
+
+    public void addTargetChange(int startIndex, int changeType, List<ObjectChange<E>> events) {
+        final int endIndex = startIndex + events.size();
+        if (!initialCapacityKnown) ensureCapacity(endIndex);
+        int j = 0;
+        for (int i = startIndex; i < endIndex; i++) {
+            final ObjectChange<E> newChange = events.get(j);
+            if (changeType == ListEvent.INSERT) {
+                tree.add(startIndex, TARGET_INDICES, INSERT, newChange, 1);
+            } else if (changeType == ListEvent.UPDATE) {
+                final int overallIndex = tree.convertIndexColor(i, TARGET_INDICES, ALL_INDICES);
+                Element<ObjectChange<E>> standingChangeToIndex = tree.get(overallIndex, ALL_INDICES);
+                if (horribleHackPreferMostRecentValue) {
+                    byte newColor = standingChangeToIndex.getColor() == INSERT ? INSERT : UPDATE;
+                    tree.set(overallIndex, ALL_INDICES, newColor, newChange, 1);
+                } else {
+                    if (standingChangeToIndex.getColor() == INSERT) {
+                        // when updating a insert the original insert stands with the new updated value
+                        tree.set(overallIndex, ALL_INDICES, INSERT, ObjectChange.create(ListEvent.unknownValue(), newChange.getNewValue()), 1);
+                    } else if (standingChangeToIndex.getColor() == UPDATE) {
+                        // if we're updating an update, the original replaced value stands.
+                        tree.set(overallIndex, ALL_INDICES, UPDATE, ObjectChange.create(standingChangeToIndex.get().getOldValue(), newChange.getNewValue()), 1);
+                    } else {
+                        // apply the update to our change description
+                        tree.set(overallIndex, ALL_INDICES, UPDATE, newChange, 1);
+                    }
+                }
+            } else if (changeType == ListEvent.DELETE) {
+                if (startIndex > 0 && startIndex > tree.size(TARGET_INDICES)) {
+                    throw new IllegalArgumentException();
+                }
+                final int overallIndex = tree.convertIndexColor(startIndex, TARGET_INDICES, ALL_INDICES);
+                Element<ObjectChange<E>> standingChangeToIndex = tree.get(overallIndex, ALL_INDICES);
+                // if we're deleting an insert, remove that insert
+                if (standingChangeToIndex.getColor() == INSERT) {
+                    if (!allowContradictingEvents)
+                        throw new IllegalStateException("Remove " + i + " undoes prior insert at the same index! Consider enabling contradicting events.");
+                    tree.remove(overallIndex, ALL_INDICES, 1);
+                } // if we're deleting an update/delete, the original replaced value stands.
+                else if (standingChangeToIndex.getColor() == UPDATE || standingChangeToIndex.getColor() == DELETE) {
+                    tree.set(overallIndex, ALL_INDICES, DELETE, ObjectChange.create(standingChangeToIndex.get()
+                            .getOldValue(), ListEvent.unknownValue()), 1);
+                } else {
+                    tree.set(overallIndex, ALL_INDICES, DELETE, newChange, 1);
+                }
+            }
+            j++;
+        }
+
     }
 
     /**
      * <p>We should consider removing the loop by only setting on removed elements.
      *
-     * @param oldValue the previous value being replaced
-     * @param newValue the new value
+     * @param oldValue   the previous value being replaced
+     * @param newValue   the new value
      * @param startIndex the first updated element, inclusive
-     * @param endIndex the last index, exclusive
+     * @param endIndex   the last index, exclusive
+     * @deprecated use {@link #addTargetChange(int, int, List)}
      */
+    @Deprecated
     public void targetUpdate(int startIndex, int endIndex, E oldValue, E newValue) {
-        if(!initialCapacityKnown) ensureCapacity(endIndex);
-        for(int i = startIndex; i < endIndex; i++) {
-            int overallIndex = tree.convertIndexColor(i, TARGET_INDICES, ALL_INDICES);
-            Element<E> standingChangeToIndex = tree.get(overallIndex, ALL_INDICES);
-
-            if(horribleHackPreferMostRecentValue) {
-                byte newColor = standingChangeToIndex.getColor() == INSERT ? INSERT : UPDATE;
-                tree.set(overallIndex, ALL_INDICES, newColor, oldValue, 1);
-                continue;
-            }
-
-            // don't bother updating an inserted element
-            if(standingChangeToIndex.getColor() == INSERT) {
-                continue;
-            }
-
-            // if we're updating an update, the original replaced value stands.
-            if(standingChangeToIndex.getColor() == UPDATE) {
-                oldValue = standingChangeToIndex.get();
-            }
-
-            // apply the update to our change description
-            tree.set(overallIndex, ALL_INDICES, UPDATE, oldValue, 1);
-        }
+        this.addTargetChange(startIndex, ListEvent.UPDATE, Collections.nCopies(endIndex - startIndex, ObjectChange.create
+                (oldValue, newValue)));
     }
 
     /**
@@ -108,12 +146,14 @@ public class Tree4Deltas<E> {
      * changes.
      *
      * @param startIndex the first inserted element, inclusive
-     * @param endIndex the last index, exclusive
-     * @param newValue the inserted value
+     * @param endIndex   the last index, exclusive
+     * @param newValue   the inserted value
+     * @deprecated use {@link #addTargetChange(int, int, List)}
      */
+    @Deprecated
     public void targetInsert(int startIndex, int endIndex, E newValue) {
-        if(!initialCapacityKnown) ensureCapacity(endIndex);
-        tree.add(startIndex, TARGET_INDICES, INSERT, newValue, endIndex - startIndex);
+        this.addTargetChange(startIndex, ListEvent.INSERT, Collections.nCopies(endIndex - startIndex, ObjectChange.create
+                (ListEvent.unknownValue(), newValue)));
     }
 
     /**
@@ -122,36 +162,18 @@ public class Tree4Deltas<E> {
      * then removing everything else...
      *
      * @param startIndex the index of the first element to remove
-     * @param endIndex the last index, exclusive
-     * @param value the removed value
+     * @param endIndex   the last index, exclusive
+     * @param value      the removed value
+     * @deprecated use {@link #addTargetChange(int, int, List)}
      */
+    @Deprecated
     public void targetDelete(int startIndex, int endIndex, E value) {
-        if(!initialCapacityKnown) ensureCapacity(endIndex);
-        for(int i = startIndex; i < endIndex; i++) {
-            if(startIndex > 0 && startIndex > tree.size(TARGET_INDICES)) {
-                throw new IllegalArgumentException();
-            }
-            int overallIndex = tree.convertIndexColor(startIndex, TARGET_INDICES, ALL_INDICES);
-            Element<E> standingChangeToIndex = tree.get(overallIndex, ALL_INDICES);
-
-            // if we're deleting an insert, remove that insert
-            if(standingChangeToIndex.getColor() == INSERT) {
-                if(!allowContradictingEvents) throw new IllegalStateException("Remove " + i + " undoes prior insert at the same index! Consider enabling contradicting events.");
-                tree.remove(overallIndex, ALL_INDICES, 1);
-                continue;
-            }
-
-            // if we're deleting an update, the original replaced value stands.
-            if(standingChangeToIndex.getColor() == UPDATE) {
-                value = standingChangeToIndex.get();
-            }
-
-            tree.set(overallIndex, ALL_INDICES, DELETE, value, 1);
-       }
+        this.addTargetChange(startIndex, ListEvent.DELETE, Collections.nCopies(endIndex - startIndex, ObjectChange.create
+                (value, ListEvent.unknownValue())));
     }
 
     public void sourceInsert(int sourceIndex) {
-        tree.add(sourceIndex, SOURCE_INDICES, NO_CHANGE, ListEvent.<E>unknownValue(), 1);
+        tree.add(sourceIndex, SOURCE_INDICES, NO_CHANGE, ObjectChange.unknownChange(), 1);
     }
 
     public void sourceDelete(int sourceIndex) {
@@ -159,7 +181,7 @@ public class Tree4Deltas<E> {
     }
 
     public void sourceRevert(int sourceIndex) {
-        tree.set(sourceIndex, SOURCE_INDICES, NO_CHANGE, ListEvent.<E>unknownValue(), 1);
+        tree.set(sourceIndex, SOURCE_INDICES, NO_CHANGE, ObjectChange.unknownChange(), 1);
     }
 
     public int targetSize() {
@@ -178,15 +200,21 @@ public class Tree4Deltas<E> {
      * Get the value at the specified target index.
      *
      * @return the value, or {@link ListEvent#UNKNOWN_VALUE} if this index
-     *     holds a value that hasn't been buffered. In this case, the value
-     *     can be obtained from the source list.
+     * holds a value that hasn't been buffered. In this case, the value
+     * can be obtained from the source list.
      */
     public E getTargetValue(int targetIndex) {
-        return tree.get(targetIndex, TARGET_INDICES).get();
+        final Element<ObjectChange<E>> change = tree.get(targetIndex, TARGET_INDICES);
+        if (change == null) return null;
+        if (change.getColor() == INSERT) return change.get().getNewValue();
+        return change.get().getOldValue();
     }
 
     public E getSourceValue(int sourceIndex) {
-        return tree.get(sourceIndex, SOURCE_INDICES).get();
+        final Element<ObjectChange<E>> change = tree.get(sourceIndex, SOURCE_INDICES);
+        if (change == null) return null;
+        if (change.getColor() == INSERT) return change.get().getNewValue();
+        return change.get().getOldValue();
     }
 
     public void reset(int size) {
@@ -194,12 +222,15 @@ public class Tree4Deltas<E> {
         initialCapacityKnown = true;
         ensureCapacity(size);
     }
+
     private void ensureCapacity(int size) {
         int currentSize = tree.size(TARGET_INDICES);
         int delta = size - currentSize;
-        if(delta > 0) {
+        if (delta > 0) {
             int endOfTree = tree.size(ALL_INDICES);
-            tree.add(endOfTree, ALL_INDICES, NO_CHANGE, ListEvent.<E>unknownValue(), delta);
+            for (int i = 0; i < delta; i++) {
+                tree.add(endOfTree, ALL_INDICES, NO_CHANGE, ObjectChange.unknownChange(), 1);
+            }
         }
     }
 
@@ -207,22 +238,11 @@ public class Tree4Deltas<E> {
      * Add all the specified changes to this.
      */
     public void addAll(BlockSequence<E> blocks) {
-        for(BlockSequence<E>.Iterator i = blocks.iterator(); i.nextBlock(); ) {
+        for (BlockSequence<E>.Iterator i = blocks.iterator(); i.nextBlock(); ) {
             int blockStart = i.getBlockStart();
-            int blockEnd = i.getBlockEnd();
             int type = i.getType();
-            E oldValue = i.getOldValue();
-            E newValue = i.getNewValue();
-
-            if(type == ListEvent.INSERT) {
-                targetInsert(blockStart, blockEnd, newValue);
-            } else if(type == ListEvent.UPDATE) {
-                targetUpdate(blockStart, blockEnd, oldValue, newValue);
-            } else if(type == ListEvent.DELETE) {
-                targetDelete(blockStart, blockEnd, oldValue);
-            } else {
-                throw new IllegalStateException();
-            }
+            List<ObjectChange<E>> blockChanges = i.getBlockChanges();
+            addTargetChange(blockStart, type, blockChanges);
         }
     }
 
@@ -247,18 +267,19 @@ public class Tree4Deltas<E> {
      */
     public static class Iterator<E> {
 
-        private final FourColorTree<E> tree;
-        private final FourColorTreeIterator<E> treeIterator;
+        private final FourColorTree<ObjectChange<E>> tree;
+        private final FourColorTreeIterator<ObjectChange<E>> treeIterator;
 
-        private Iterator(FourColorTree<E> tree) {
+        private Iterator(FourColorTree<ObjectChange<E>> tree) {
             this.tree = tree;
             this.treeIterator = new FourColorTreeIterator<>(tree);
         }
 
-        private Iterator(FourColorTree<E> tree, FourColorTreeIterator<E> treeIterator) {
+        private Iterator(FourColorTree<ObjectChange<E>> tree, FourColorTreeIterator<ObjectChange<E>> treeIterator) {
             this.tree = tree;
             this.treeIterator = treeIterator;
         }
+
         public Iterator<E> copy() {
             return new Iterator<>(tree, treeIterator.copy());
         }
@@ -266,6 +287,11 @@ public class Tree4Deltas<E> {
         public int getIndex() {
             return treeIterator.index(TARGET_INDICES);
         }
+
+        public int getStartIndex() {
+            return treeIterator.nodeStartIndex(TARGET_INDICES);
+        }
+
         public int getEndIndex() {
             // this is peculiar. We add mixed types - an index of current indices
             // plus the size of "all indices". . . this is because we describe the
@@ -276,30 +302,47 @@ public class Tree4Deltas<E> {
 
         public int getType() {
             byte color = treeIterator.color();
-            if(color == INSERT) return ListEvent.INSERT;
-            else if(color == UPDATE) return ListEvent.UPDATE;
-            else if(color == DELETE) return ListEvent.DELETE;
+            if (color == INSERT) return ListEvent.INSERT;
+            else if (color == UPDATE) return ListEvent.UPDATE;
+            else if (color == DELETE) return ListEvent.DELETE;
             else throw new IllegalStateException();
         }
+
         public boolean next() {
-            if(!hasNext()) return false;
+            if (!hasNext()) return false;
             treeIterator.next(CHANGE_INDICES);
             return true;
         }
+
         public boolean nextNode() {
-            if(!hasNextNode()) return false;
+            if (!hasNextNode()) return false;
             treeIterator.nextNode(CHANGE_INDICES);
             return true;
         }
+
         public boolean hasNext() {
             return treeIterator.hasNext(CHANGE_INDICES);
         }
+
         public boolean hasNextNode() {
             return treeIterator.hasNextNode(CHANGE_INDICES);
         }
 
         public E getOldValue() {
-            return treeIterator.node().get();
+            final Element<ObjectChange<E>> element = treeIterator.node();
+            return element.get().getOldValue();
+        }
+
+        public E getNewValue() {
+            final Element<ObjectChange<E>> element = treeIterator.node();
+            return element.get().getNewValue();
+        }
+
+        public List<ObjectChange<E>> getBlockChanges() {
+            final Element<ObjectChange<E>> node = treeIterator.node();
+            final int size = treeIterator.nodeSize(ALL_INDICES);
+            if (size == 1) return Collections.singletonList(node.get());
+            return Collections.nCopies(size, node.get());
         }
     }
 }

--- a/core/src/test/java/ca/odell/glazedlists/swing/EventTableModelTest.java
+++ b/core/src/test/java/ca/odell/glazedlists/swing/EventTableModelTest.java
@@ -450,7 +450,7 @@ public class EventTableModelTest extends SwingTestCase {
         assertEquals(GlazedListsTests.stringToList("B"), selModel.getSelected());
         assertEquals(GlazedListsTests.delimitedStringToList("A C D E F"), selModel.getDeselected());
         list.removeAll(GlazedListsTests.delimitedStringToList("E F"));
-        assertEquals(2, counter.getCountAndReset());
+        assertEquals(1, counter.getCountAndReset());
         assertEquals(GlazedListsTests.stringToList("B"), selModel.getSelected());
         assertEquals(GlazedListsTests.delimitedStringToList("A C D"), selModel.getDeselected());
     }

--- a/extensions/javafx/src/main/java/ca/odell/glazedlists/javafx/EventObservableList.java
+++ b/extensions/javafx/src/main/java/ca/odell/glazedlists/javafx/EventObservableList.java
@@ -7,6 +7,7 @@ import ca.odell.glazedlists.EventList;
 import ca.odell.glazedlists.event.ListEvent;
 import ca.odell.glazedlists.event.ListEventListener;
 
+import ca.odell.glazedlists.event.ObjectChange;
 import javafx.beans.InvalidationListener;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
@@ -619,7 +620,13 @@ public class EventObservableList<E> extends AbstractList<E> implements Observabl
 
         @Override
         public List<E> getRemoved() {
-            return Collections.singletonList(changes.getOldValue());
+            final List<ObjectChange<E>> changed = changes.getBlockChanges();
+            final List<E> removed = new ArrayList<>(changed.size());
+            for(int i = 0; i<changed.size(); i++){
+                final ObjectChange<E> c = changed.get(i);
+                removed.add(c.getOldValue());
+            }
+            return removed;
         }
 
         // @Override

--- a/extensions/javafx/src/test/java/ca/odell/glazedlists/javafx/EventObservableListTest.java
+++ b/extensions/javafx/src/test/java/ca/odell/glazedlists/javafx/EventObservableListTest.java
@@ -496,8 +496,7 @@ public class EventObservableListTest {
 
         // removeAll (Collection)
         root.removeAll(asList("Kiwi", "Jack fruit"));
-        expectEvent(expectation(ChangeType.DELETE, 9, 10, null, asList("Jack fruit")),
-                expectation(ChangeType.DELETE, 9, 10, null, asList("Kiwi")));
+        expectEvent(expectation(ChangeType.DELETE, 9, 11, null, asList("Jack fruit", "Kiwi")));
         assertEquals(9, wrapper.size());
         assertEquals(9, root.size());
         assertEquals("Apple", wrapper.get(0));
@@ -542,13 +541,8 @@ public class EventObservableListTest {
 
         // clear
         root.clear();
-        expectEvent(expectation(ChangeType.DELETE, 0, 1, null, asList("Apple")),
-                expectation(ChangeType.DELETE, 0, 1, null, asList("Banana")),
-                expectation(ChangeType.DELETE, 0, 1, null, asList("Cantaloupe")),
-                expectation(ChangeType.DELETE, 0, 1, null, asList("Elderberry")),
-                expectation(ChangeType.DELETE, 0, 1, null, asList("Fig")),
-                expectation(ChangeType.DELETE, 0, 1, null, asList("Grape")),
-                expectation(ChangeType.DELETE, 0, 1, null, asList("Honeydew")));
+        expectEvent(expectation(ChangeType.DELETE, 0, 7, null, asList("Apple", "Banana", "Cantaloupe", "Elderberry",
+                "Fig", "Grape", "Honeydew")));
         assertTrue(wrapper.isEmpty());
         assertTrue(root.isEmpty());
         assertEquals(0, wrapper.size());


### PR DESCRIPTION
I have properly implemented getOldValue/getNewValue preserving the public API. The GC pressure could potentially be much higher as before (because of more object creation) but the overall event performance should be better.
I have also fixed the BlockSequence implementation (like in the old 1.5 (?) glazedlists days) so that it covers more cases.