### PR TITLE
Support CONTAINS in strict mode

### DIFF
--- a/core/src/test/java/ca/odell/glazedlists/swing/AutoCompleteSupportTestApp.java
+++ b/core/src/test/java/ca/odell/glazedlists/swing/AutoCompleteSupportTestApp.java
@@ -131,6 +131,8 @@ public class AutoCompleteSupportTestApp {
         new Location("USA", "Wyoming", "Cheyenne")
     };
 
+    private static final String GL_DISABLE_CONTAINS_PREFER_STARTS_WITH = "GL:DisableContainsPreferStartsWith";
+
     /** The currently installed look and feel. */
     private String currentLookAndFeel;
 
@@ -187,6 +189,9 @@ public class AutoCompleteSupportTestApp {
     /** A checkbox to toggle whether the {@link #autoCompleteSupport} hides the popup menu when losing focus. */
     private final JCheckBox hidesPopupOnFocusLostCheckBox = new JCheckBox();
 
+    /** A checkbox to toggle whether the {@link #autoCompleteSupport} prefer a startsWith match when CONTAINS. */
+    private final JCheckBox containsPreferStartsWithCheckBox = new JCheckBox();
+
     /** The ButtonGroup to which all Look & Feel radio buttons belong. */
     private final ButtonGroup lafMenuGroup = new ButtonGroup();
 
@@ -236,6 +241,9 @@ public class AutoCompleteSupportTestApp {
 
         hidesPopupOnFocusLostCheckBox.addActionListener(new HidePopupOnFocusLostActionHandler());
         hidesPopupOnFocusLostCheckBox.setSelected(autoCompleteSupport.getHidesPopupOnFocusLost());
+
+        containsPreferStartsWithCheckBox.addActionListener(new PreferStartsWithActionHandler());
+        containsPreferStartsWithCheckBox.setSelected(!Boolean.TRUE.equals(autoCompleteComboBox.getClientProperty(GL_DISABLE_CONTAINS_PREFER_STARTS_WITH)));
 
         frame.pack();
         frame.setLocationRelativeTo(null);
@@ -364,6 +372,15 @@ public class AutoCompleteSupportTestApp {
         }
     }
 
+    private class PreferStartsWithActionHandler implements ActionListener {
+        @Override
+        public void actionPerformed(ActionEvent e)
+        {
+            autoCompleteComboBox.putClientProperty(GL_DISABLE_CONTAINS_PREFER_STARTS_WITH,
+                    !containsPreferStartsWithCheckBox.isSelected() ? Boolean.TRUE : null);
+        }
+    }
+
     private class FilterModeActionHandler implements ActionListener {
         private final int mode;
 
@@ -406,8 +423,11 @@ public class AutoCompleteSupportTestApp {
         panel.add(new JLabel("Hide Popup on Focus Lost:"),  new GridBagConstraints(0, 3, 1, 1, 0.0, 0.0, GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(0, 0, 0, 5), 0, 0));
         panel.add(hidesPopupOnFocusLostCheckBox,            new GridBagConstraints(1, 3, 1, 1, 0.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));
 
-        panel.add(new JLabel("Filter Mode:"),               new GridBagConstraints(0, 4, 1, 1, 0.0, 0.0, GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(0, 0, 0, 5), 0, 0));
-        panel.add(filterModePanel,                          new GridBagConstraints(1, 4, 1, 1, 0.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));
+        panel.add(new JLabel("Prefer Starts With Match:"),  new GridBagConstraints(0, 5, 1, 1, 0.0, 0.0, GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(0, 0, 0, 5), 0, 0));
+        panel.add(containsPreferStartsWithCheckBox,         new GridBagConstraints(1, 5, 1, 1, 0.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));
+
+        panel.add(new JLabel("Filter Mode:"),               new GridBagConstraints(0, 6, 1, 1, 0.0, 0.0, GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(0, 0, 0, 5), 0, 0));
+        panel.add(filterModePanel,                          new GridBagConstraints(1, 6, 1, 1, 0.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));
 
         return panel;
     }

--- a/core/src/test/java/ca/odell/glazedlists/swing/AutoCompleteSupportTestApp.java
+++ b/core/src/test/java/ca/odell/glazedlists/swing/AutoCompleteSupportTestApp.java
@@ -131,7 +131,7 @@ public class AutoCompleteSupportTestApp {
         new Location("USA", "Wyoming", "Cheyenne")
     };
 
-    private static final String GL_DISABLE_CONTAINS_PREFER_STARTS_WITH = "GL:DisableContainsPreferStartsWith";
+    private static final String GL_ENABLE_NON_STRICT_CONTAINS_SELECTION = "GL:SelectContains";
 
     /** The currently installed look and feel. */
     private String currentLookAndFeel;
@@ -190,7 +190,7 @@ public class AutoCompleteSupportTestApp {
     private final JCheckBox hidesPopupOnFocusLostCheckBox = new JCheckBox();
 
     /** A checkbox to toggle whether the {@link #autoCompleteSupport} prefer a startsWith match when CONTAINS. */
-    private final JCheckBox containsPreferStartsWithCheckBox = new JCheckBox();
+    private final JCheckBox selectNonStrictContainsCheckBox = new JCheckBox();
 
     /** The ButtonGroup to which all Look & Feel radio buttons belong. */
     private final ButtonGroup lafMenuGroup = new ButtonGroup();
@@ -242,8 +242,9 @@ public class AutoCompleteSupportTestApp {
         hidesPopupOnFocusLostCheckBox.addActionListener(new HidePopupOnFocusLostActionHandler());
         hidesPopupOnFocusLostCheckBox.setSelected(autoCompleteSupport.getHidesPopupOnFocusLost());
 
-        containsPreferStartsWithCheckBox.addActionListener(new PreferStartsWithActionHandler());
-        containsPreferStartsWithCheckBox.setSelected(!Boolean.TRUE.equals(autoCompleteComboBox.getClientProperty(GL_DISABLE_CONTAINS_PREFER_STARTS_WITH)));
+
+        selectNonStrictContainsCheckBox.addActionListener(new SelectNonStrictContainsActionHandler());
+        selectNonStrictContainsCheckBox.setSelected(Boolean.TRUE.equals(autoCompleteComboBox.getClientProperty(GL_ENABLE_NON_STRICT_CONTAINS_SELECTION)));
 
         frame.pack();
         frame.setLocationRelativeTo(null);
@@ -372,12 +373,12 @@ public class AutoCompleteSupportTestApp {
         }
     }
 
-    private class PreferStartsWithActionHandler implements ActionListener {
+    private class SelectNonStrictContainsActionHandler implements ActionListener {
         @Override
         public void actionPerformed(ActionEvent e)
         {
-            autoCompleteComboBox.putClientProperty(GL_DISABLE_CONTAINS_PREFER_STARTS_WITH,
-                    !containsPreferStartsWithCheckBox.isSelected() ? Boolean.TRUE : null);
+            autoCompleteComboBox.putClientProperty(GL_ENABLE_NON_STRICT_CONTAINS_SELECTION,
+                    selectNonStrictContainsCheckBox.isSelected() ? Boolean.TRUE : null);
         }
     }
 
@@ -423,8 +424,8 @@ public class AutoCompleteSupportTestApp {
         panel.add(new JLabel("Hide Popup on Focus Lost:"),  new GridBagConstraints(0, 3, 1, 1, 0.0, 0.0, GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(0, 0, 0, 5), 0, 0));
         panel.add(hidesPopupOnFocusLostCheckBox,            new GridBagConstraints(1, 3, 1, 1, 0.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));
 
-        panel.add(new JLabel("Prefer Starts With Match:"),  new GridBagConstraints(0, 5, 1, 1, 0.0, 0.0, GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(0, 0, 0, 5), 0, 0));
-        panel.add(containsPreferStartsWithCheckBox,         new GridBagConstraints(1, 5, 1, 1, 0.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));
+        panel.add(new JLabel("Select NonStrict Contains:"), new GridBagConstraints(0, 4, 1, 1, 0.0, 0.0, GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(0, 0, 0, 5), 0, 0));
+        panel.add(selectNonStrictContainsCheckBox,          new GridBagConstraints(1, 4, 1, 1, 0.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));
 
         panel.add(new JLabel("Filter Mode:"),               new GridBagConstraints(0, 6, 1, 1, 0.0, 0.0, GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(0, 0, 0, 5), 0, 0));
         panel.add(filterModePanel,                          new GridBagConstraints(1, 6, 1, 1, 0.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));

--- a/extensions/icu4j/src/test/java/ca/odell/glazedlists/swing/AutoCompleteSupportTest.java
+++ b/extensions/icu4j/src/test/java/ca/odell/glazedlists/swing/AutoCompleteSupportTest.java
@@ -38,6 +38,7 @@ import javax.swing.text.AttributeSet;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.Document;
 import javax.swing.text.Element;
+import javax.swing.text.JTextComponent;
 import javax.swing.text.Position;
 import javax.swing.text.Segment;
 
@@ -1030,6 +1031,208 @@ public class AutoCompleteSupportTest extends SwingTestCase {
         Thread.sleep(250); // wait for the EDT to process the change to items
         assertEquals("hoobedy", textField.getText());
         assertEquals("hoobedy", combo.getSelectedItem());
+    }
+
+    /**
+     * If there is no selection, then return caret position.
+     * If there is a selection, it must include the end of the text, else null;
+     * return the lowest value of selection begin/end.
+     */
+    private static Integer findSelectionStartToEnd(JTextComponent text) {
+        int start = text.getSelectionStart();
+        int end = text.getSelectionEnd();
+        if (start == end)
+            return start;
+        if (Integer.max(start,end) != text.getDocument().getLength())
+            return null;
+        return Integer.min(start,end);
+    }
+
+    private static final String GL_DISABLE_CONTAINS_PREFER_STARTS_WITH = "GL:DisableContainsPreferStartsWith";
+
+    /**
+     * Test contains/exactMatch/preferStartsWith interactions;
+     * verify text, selected text, caret position and selected item after each input.
+     * With dropdown values "xabcdex", "ab", "abcd",
+     * enter the chars: "abcde", matching "ab", "abcd", "xabcdex".
+     * {@literal <BS>} removes selection "x",
+     * {@literal <BS>} get's back to "abcd" input/match
+     */
+    @Test
+    public void testContainsPreferStartsWith() throws BadLocationException {
+        final JComboBox<String> combo = new JComboBox<>();
+
+        final JTextField textField = (JTextField) combo.getEditor().getEditorComponent();
+        final AbstractDocument doc = (AbstractDocument) textField.getDocument();
+
+        final EventList<String> items = new BasicEventList<>();
+        items.add("xabcdex");
+        items.add("ab");
+        items.add("abcd");
+
+        AutoCompleteSupport<String> support = AutoCompleteSupport.install(combo, items);
+        final ComboBoxModel<String> model = combo.getModel();
+        support.setFilterMode(TextMatcherEditor.CONTAINS);
+        assertEquals(false, Boolean.TRUE.equals(combo.getClientProperty(GL_DISABLE_CONTAINS_PREFER_STARTS_WITH)));
+        assertEquals(TextMatcherEditor.IDENTICAL_STRATEGY, support.getTextMatchingStrategy());
+
+        Integer selStart;
+
+        // type "a", match "ab" since prefer starts with
+        doc.replace(0, 0, "a", null);
+        assertEquals(2, textField.getCaretPosition());
+        assertEquals("ab", model.getSelectedItem());
+        assertEquals("b", textField.getSelectedText());
+
+        selStart = findSelectionStartToEnd(textField);
+        assertNotNull(selStart);
+        assertEquals(1, (int)selStart);
+
+        // type "b" replaces "b", match "ab" since exact and prefer starts with
+        doc.replace(selStart, doc.getLength() - selStart, "b", null);
+        assertEquals(2, textField.getCaretPosition());
+        assertEquals("ab", model.getSelectedItem());
+        assertEquals(null, textField.getSelectedText());
+
+        selStart = findSelectionStartToEnd(textField);
+        assertNotNull(selStart);
+        assertEquals(2, (int)selStart);
+
+        // type "c", match "abcd"
+        doc.replace(selStart, doc.getLength() - selStart, "c", null);
+        assertEquals(4, textField.getCaretPosition());
+        assertEquals("abcd", model.getSelectedItem());
+        assertEquals("d", textField.getSelectedText());
+
+        selStart = findSelectionStartToEnd(textField);
+        assertNotNull(selStart);
+        assertEquals(3, (int)selStart);
+
+        // type "d", match "abcd"
+        doc.replace(selStart, doc.getLength() - selStart, "d", null);
+        assertEquals(4, textField.getCaretPosition());
+        assertEquals("abcd", model.getSelectedItem());
+        assertEquals(null, textField.getSelectedText());
+
+        selStart = findSelectionStartToEnd(textField);
+        assertNotNull(selStart);
+        assertEquals(4, (int)selStart);
+
+        // type "e", match "xabcdex" since contains and no starts with match
+        doc.replace(selStart, doc.getLength() - selStart, "e", null);
+        assertEquals(7, textField.getCaretPosition());
+        assertEquals("xabcdex", model.getSelectedItem());
+        assertEquals("x", textField.getSelectedText());
+
+        selStart = findSelectionStartToEnd(textField);
+        assertNotNull(selStart);
+        assertEquals(6, (int)selStart);
+        
+        // type <BS>, remove selection "x", input is "abcde",
+        // still see "xabcdex" in combo list
+        // caret is after "e", no selection
+        doc.remove(6, 1);
+        assertEquals(6, textField.getCaretPosition());
+        assertEquals("xabcdex", model.getSelectedItem());
+        assertEquals(null, textField.getSelectedText());
+        
+        // type <BS>, remove "e", input is now "abcd", back to "abcd" match
+        doc.remove(5, 1);
+        assertEquals(4, textField.getCaretPosition());
+        assertEquals("abcd", model.getSelectedItem());
+        assertEquals(null, textField.getSelectedText());
+    }
+
+    /**
+     * Test contains/exactMatch/notPreferStartsWith interactions.
+     * Like the previous, but disable ContainsPreferStartsWith
+     * Enter the chars: "abcde",
+     * match: "xabcdex", "ab", "xabcdex", "abcd", "xabcdex".
+     * The matches to "ab" and "abcd" are because of exact match.
+     */
+    @Test
+    public void testContainsPreferStartsWithNot() throws BadLocationException {
+        final JComboBox<String> combo = new JComboBox<>();
+
+        final JTextField textField = (JTextField) combo.getEditor().getEditorComponent();
+        final AbstractDocument doc = (AbstractDocument) textField.getDocument();
+
+        final EventList<String> items = new BasicEventList<>();
+        items.add("xabcdex");
+        items.add("ab");
+        items.add("abcd");
+
+        AutoCompleteSupport<String> support = AutoCompleteSupport.install(combo, items);
+        final ComboBoxModel<String> model = combo.getModel();
+        support.setFilterMode(TextMatcherEditor.CONTAINS);
+        combo.putClientProperty(GL_DISABLE_CONTAINS_PREFER_STARTS_WITH, true);
+        assertEquals(TextMatcherEditor.IDENTICAL_STRATEGY, support.getTextMatchingStrategy());
+
+        Integer selStart;
+
+        // type "a", match "xabcdex" since prefer starts with
+        doc.replace(0, 0, "a", null);
+        assertEquals(7, textField.getCaretPosition());
+        assertEquals("xabcdex", model.getSelectedItem());
+        assertEquals("bcdex", textField.getSelectedText());
+
+        selStart = findSelectionStartToEnd(textField);
+        assertNotNull(selStart);
+        assertEquals(2, (int)selStart);
+
+        // type "b" replaces "bcdex", match "ab" since exact match
+        doc.replace(selStart, doc.getLength() - selStart, "b", null);
+        assertEquals(2, textField.getCaretPosition());
+        assertEquals("ab", model.getSelectedItem());
+        assertEquals(null, textField.getSelectedText());
+
+        selStart = findSelectionStartToEnd(textField);
+        assertNotNull(selStart);
+        assertEquals(2, (int)selStart);
+
+        // type "c", match "xabcdex"
+        doc.replace(selStart, doc.getLength() - selStart, "c", null);
+        assertEquals(7, textField.getCaretPosition());
+        assertEquals("xabcdex", model.getSelectedItem());
+        assertEquals("dex", textField.getSelectedText());
+
+        selStart = findSelectionStartToEnd(textField);
+        assertNotNull(selStart);
+        assertEquals(4, (int)selStart);
+    
+        // type "d", match "abcd" match since exact
+        doc.replace(selStart, doc.getLength() - selStart, "d", null);
+        assertEquals(4, textField.getCaretPosition());
+        assertEquals("abcd", model.getSelectedItem());
+        assertEquals(null, textField.getSelectedText());
+
+        selStart = findSelectionStartToEnd(textField);
+        assertNotNull(selStart);
+        assertEquals(4, (int)selStart);
+
+        // type "e", match "xabcdex" since contains
+        doc.replace(selStart, doc.getLength() - selStart, "e", null);
+        assertEquals(7, textField.getCaretPosition());
+        assertEquals("xabcdex", model.getSelectedItem());
+        assertEquals("x", textField.getSelectedText());
+        
+        selStart = findSelectionStartToEnd(textField);
+        assertNotNull(selStart);
+        assertEquals(6, (int)selStart);
+
+        // type <BS>, remove selection "x", input is "abcde",
+        // still see "xabcdex" in combo list
+        // caret is after "e", no selection
+        doc.remove(6, 1);
+        assertEquals(6, textField.getCaretPosition());
+        assertEquals("xabcdex", model.getSelectedItem());
+        assertEquals(null, textField.getSelectedText());
+        
+        // type <BS>, remove "e", input is now "abcd", back to "abcd" match
+        doc.remove(5, 1);
+        assertEquals(4, textField.getCaretPosition());
+        assertEquals("abcd", model.getSelectedItem());
+        assertEquals(null, textField.getSelectedText());
     }
 
     private static class NoopDocument implements Document {


### PR DESCRIPTION
@hbrands 
An experimental/draft PR. It seems to work and feels OK. Below are next steps and some question.
See https://github.com/glazedlists/glazedlists/issues/676#issuecomment-753006023 for some UI issues.

With some general concordance, I'll proceed with an implementation using the following AutoCompleteSupport inner classes. This structure should be compatible with introducing a fuzzy matcher at some future date. During implementation, I suspect the following can be simplified a little.

```
private abstract class UserTextFilter {
    private Matcher<String> filterMatcher; // was instance variable filterMatcher
    boolean matches(String itemString);
    String determineUserText(); // from postProcessDocumentChange (leaves no state)
    updateFilter(userText); // create new filterMatcher 
    visualizeFilter() // text selection or otherwise highlight user input
    selectedMatchString(matchString) // use to set offset, track prefix
}
private class PrefixFilter extends UserTextFilter {} // starts_with as today
private class ContainsFilter extends UserTextFilter {} // contains
private class FuzzyFilter extends UserTextFilter {} // FUTURE
```

The current experiment uses the old code and only does different stuff when strict+contains. The above proposal, is not quite like that...

**Some questions, issues, comments**

- Are there any tests for user filtering?
- Still need to look through setStrict(), other state changes, for tweaking.
- Anything needed in decorateCurrentUI()?
- selectAutoCompleteTerm() - when (getCorrectsCase() || isStrict())
any reason not to just replace all the text?
- handle NORMALIZED_STRATEGY, ICU4J when determining user text chars
Currently just using comboText.indexOf(prefix). Would be nice to look at results of TextMatcher.
- findAutoCompleteTerm() - experiment is overly complicated
Current handling if no exact match
  - v1.11: uses STARTS_WITH
  - draft/experiment: checks both STARTS_WITH and CONTAINS, prefers STARTS_WITH
  - suggest: if isStrictContains() then only CONTAINS?
    or if filterMode==CONTAINS regardless of strict, then CONTAINS?
