### PR TITLE
Option to keep caret at text insertion point

### DIFF
--- a/core/src/main/java/ca/odell/glazedlists/swing/AutoCompleteSupport.java
+++ b/core/src/main/java/ca/odell/glazedlists/swing/AutoCompleteSupport.java
@@ -171,6 +171,7 @@ import ca.odell.glazedlists.impl.filter.TextSearchStrategy;
  *   <li> {@link #setBeepOnStrictViolation(boolean)}
  *   <li> {@link #setSelectsTextOnFocusGain(boolean)}
  *   <li> {@link #setHidesPopupOnFocusLost(boolean)}
+ *   <li> {@link #setPositionCaretTowardZero(boolean)}
  *   <li> {@link #setFilterMode(int)}
  *   <li> {@link #setFirstItem(Object)}
  *   <li> {@link #removeFirstItem()}
@@ -225,6 +226,12 @@ public final class AutoCompleteSupport<E> {
      * leave the JPopupMenu visible.
      */
     private boolean hidesPopupOnFocusLost = true;
+
+    /**
+     * This controls on which side of a ComboBox text selection
+     * to place the caret.
+     */
+    private boolean positionCaretTowardZero = false;
 
     //
     // These are member variables for convenience
@@ -412,6 +419,9 @@ public final class AutoCompleteSupport<E> {
     private Action originalAquaSelectNextAction;
     private Action originalAquaSelectPreviousAction;
 
+    /** The original Action associated with SelectAll. */
+    private Action originalSelectAllAction;
+
     
     
     /**
@@ -455,6 +465,7 @@ public final class AutoCompleteSupport<E> {
         /**
          * Track location/offset of user input in current combo text.
          * {@code findInputInString("")} conventionally resets/clears info.
+         * This should be invoked whenever the combo display gets a new value.
          * @param matchString find user input in this string
          */
         abstract void findInputInString(String matchString);
@@ -463,6 +474,13 @@ public final class AutoCompleteSupport<E> {
          * Return the offset of the user input into the match string
          */
         abstract int getInputOffset();
+
+        /**
+         * Return the offset of the char after the input
+         */
+        int getInputEndOffset() {
+            return getInputOffset() + input.length();
+        }
 
         /**
          * Using given user input and mode, create/save this' filterMatcher.
@@ -482,7 +500,7 @@ public final class AutoCompleteSupport<E> {
          * @param matchString search in this string
          * @return index into matchString
          */
-        protected int indexOf(String matchString) {
+        final int indexOf(String matchString) {
             Object strategyFactory = getTextMatchingStrategy();
             if (strategyFactory instanceof TextSearchStrategy.Factory) {
                 TextSearchStrategy finder = ((TextSearchStrategy.Factory)strategyFactory).create(getFilterMode(), input);
@@ -500,6 +518,7 @@ public final class AutoCompleteSupport<E> {
         @Override
         void updateFilter(String userInput) {
             updateFilterCommon(userInput, TextMatcherEditor.STARTS_WITH);
+            dumpOffsets("PrefixFilter");
         }
 
         @Override
@@ -519,7 +538,7 @@ public final class AutoCompleteSupport<E> {
          */
         @Override
         void visualizeUserInputText() {
-            comboBoxEditorComponent.select(input.length(), document.getLength());
+            selectInComboBox(input.length(), document.getLength());
         }
 
         @Override
@@ -542,6 +561,7 @@ public final class AutoCompleteSupport<E> {
         @Override
         void updateFilter(String userInput) {
             updateFilterCommon(userInput, TextMatcherEditor.CONTAINS);
+            dumpOffsets("ContainsFilter");
         }
 
         @Override
@@ -579,7 +599,7 @@ public final class AutoCompleteSupport<E> {
          */
         @Override
         void visualizeUserInputText() {
-            comboBoxEditorComponent.select(inputOffset + input.length(), document.getLength());
+            selectInComboBox(inputOffset + input.length(), document.getLength());
         }
 
         @Override
@@ -775,6 +795,11 @@ public final class AutoCompleteSupport<E> {
         this.document = (AbstractDocument) comboBoxEditorComponent.getDocument();
         this.document.setDocumentFilter(documentFilter);
 
+        // Record original select-all action, install custom action
+        final ActionMap actionMap2 = comboBoxEditorComponent.getActionMap();
+        this.originalSelectAllAction = actionMap2.get("select-all");
+        actionMap2.put("select-all", new SelectAllAction());
+
         // install a custom renderer on the combobox, if we have built one
         if (this.renderer != null)
             comboBox.setRenderer(renderer);
@@ -807,6 +832,9 @@ public final class AutoCompleteSupport<E> {
         // restore the original ComboBoxEditor if our custom ComboBoxEditor is still installed
         if (this.comboBox.getEditor() == comboBoxEditor)
             this.comboBox.setEditor(comboBoxEditor.getDelegate());
+
+        final ActionMap actionMap2 = comboBoxEditorComponent.getActionMap();
+        actionMap2.put("select-all", originalSelectAllAction);
 
         // stop adjusting the popup's width according to the prototype value
         this.popupMenu.removePopupMenuListener(popupSizerHandler);
@@ -1387,6 +1415,52 @@ public final class AutoCompleteSupport<E> {
     }
 
     /**
+     * Returns {@code true} if when {@code JComboBox} text is selected
+     * then the caret is placed at the beginning of the selection;
+     * {@code false} otherwise.
+     * 
+     * Default is {@code false}.
+     */
+    public boolean isPositionCaretTowardZero() {
+        return positionCaretTowardZero;
+    }
+
+    /**
+     * If {@code positionCaretTowardZero} is {@code true}, when a text selection is made
+     * by the {@code AutoCompleteSupport} then
+     * the caret is positioned on the side of the selection near the beginning
+     * of the string. This setting is also used when the caret is positioned
+     * at the begining or end of the text.
+     * 
+     * Default is {@code false}
+     *
+     * @throws IllegalStateException if this method is called from any Thread
+     *      other than the Swing Event Dispatch Thread
+     */
+    public void setPositionCaretTowardZero(boolean positionCaretTowardZero) {
+        checkAccessThread();
+        this.positionCaretTowardZero = positionCaretTowardZero;
+        dumpOffsets("setPosEnter");
+
+        // There are three cases to consider:
+        // 1) There is currently a selection.
+        // 2) No selection, the caret is currently at one end or the other.
+        // 3) No selection, the caret is not at either side.
+        int selectionStart = comboBoxEditorComponent.getSelectionStart();
+        int selectionEnd = comboBoxEditorComponent.getSelectionEnd();
+        if (selectionStart != selectionEnd)
+            selectInComboBox(selectionStart, selectionEnd);
+        else
+            handleCaretAfterNoTextSelection();
+        dumpOffsets("setPosExit");
+    }
+
+    private void dumpOffsets(String tag) {
+        if(false)
+        System.err.println(String.format("%s: inputOff %d, inputEnd %d, selStart %d, setEnd %d", tag, filterMatcher.getInputOffset(), filterMatcher.getInputOffset() + filterMatcher.input.length(), comboBoxEditorComponent.getSelectionStart(), comboBoxEditorComponent.getSelectionEnd()));
+    }
+
+    /**
      * Returns <tt>true</tt> if this autocomplete support instance is currently
      * installed and altering the behaviour of the combo box; <tt>false</tt> if
      * it has been {@link #uninstall}ed.
@@ -1527,6 +1601,53 @@ public final class AutoCompleteSupport<E> {
     }
 
     /**
+     * Select characters in the ComboBox; placing caret at one end
+     * of selection or the other depending on positionCaretTowardZero.
+     * Since the params may be used with TextComp.select(start, end)
+     * {@code start <= end}.
+     */
+    private void selectInComboBox(int selectionStart, int selectionEnd) {
+        assert selectionStart <= selectionEnd;
+        Caret caret = comboBoxEditorComponent.getCaret();
+        if (positionCaretTowardZero) {
+            // Place the caret at the beginning of the selection
+            // This gives max visibility to the beginning of the text.
+            caret.setDot(selectionEnd);
+            caret.moveDot(selectionStart);
+        } else {
+            caret.setDot(selectionStart);
+            caret.moveDot(selectionEnd);
+        }
+    }
+
+    /**
+     * This is typically used when there is no selection.
+     * The idea is that if the caret is at one end, position it at the other.
+     * Nothing happens if the caret is not at either end.
+     * 
+     * When moving from an endpoint,
+     * the caret should never be placed earlier than the user input.
+     */
+    private void handleCaretAfterNoTextSelection() {
+        if (comboBoxEditorComponent != null) {
+            final int caretPos = comboBoxEditorComponent.getCaretPosition();
+            final int newPos = caretPos != 0 && caretPos != document.getLength()
+                    ? caretPos : positionCaretTowardZero ? filterMatcher.getInputEndOffset() : document.getLength();
+            comboBoxEditorComponent.getCaret().setDot(newPos);
+        }
+    }
+
+    /**
+     * Action typically invoked by Ctrl-A
+     */
+    private class SelectAllAction extends AbstractAction {
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            selectInComboBox(0, document.getLength());
+        }
+    }
+
+    /**
      * This special version of EventComboBoxModel simply marks a flag to
      * indicate the items in the ComboBoxModel should not be filtered as a
      * side-effect of setting the selected item. It also marks another flag
@@ -1553,11 +1674,7 @@ public final class AutoCompleteSupport<E> {
             try {
                 super.setSelectedItem(selected);
 
-                if (comboBoxEditorComponent != null) {
-                    // remove any text selection that might exist when an item is selected
-                    final int caretPos = comboBoxEditorComponent.getCaretPosition();
-                    comboBoxEditorComponent.select(caretPos, caretPos);
-                }
+                handleCaretAfterNoTextSelection();
             } finally {
                 // reinstall the ActionListeners we removed
                 registerAllActionListeners(comboBox, listeners);
@@ -1694,9 +1811,11 @@ public final class AutoCompleteSupport<E> {
                 }
 
                 // restore the selection as it existed
-                comboBoxEditorComponent.select(selectionStart, selectionEnd);
+                comboBoxEditorComponent.setCaretPosition(selectionStart);
+                comboBoxEditorComponent.moveCaretPosition(selectionEnd);
 
                 // do not continue post processing changes
+                dumpOffsets("ProcessDocumentChange0");
                 return;
             }
 
@@ -1708,6 +1827,7 @@ public final class AutoCompleteSupport<E> {
             applyFilter(filterMatcher.input);
             selectAutoCompleteTerm(filterBypass, attributeSet, selectedItemBeforeEdit, allowPartialAutoCompletionTerm);
             togglePopup();
+            dumpOffsets("ProcessDocumentChange1");
         }
 
         /**
@@ -1859,8 +1979,10 @@ public final class AutoCompleteSupport<E> {
             // With CONTAINS handling, combo editor might have ".....input".
             // If here, didn't find "input" in model, so set editor to "input";
             // only change if there's different text to avoid perturbing caret.
-            if (!originalText.equals(input))
+            if (!originalText.equals(input)) {
                 filterBypass.replace(0, document.getLength(), input, attributeSet);
+                filterMatcher.visualizeUserInputText();
+            }
 
             // reset the selection since we couldn't find the prefix in the model
             // (this has the side-effect of scrolling the popup to the top)
@@ -2334,7 +2456,7 @@ public final class AutoCompleteSupport<E> {
         @Override
         public void focusGained(FocusEvent e) {
             if (getSelectsTextOnFocusGain())
-                comboBoxEditorComponent.select(0, comboBoxEditorComponent.getText().length());
+                selectInComboBox(0, comboBoxEditorComponent.getText().length());
         }
 
         @Override

--- a/core/src/test/java/ca/odell/glazedlists/swing/AutoCompleteSupportTestApp.java
+++ b/core/src/test/java/ca/odell/glazedlists/swing/AutoCompleteSupportTestApp.java
@@ -17,10 +17,18 @@ import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
 import javax.swing.AbstractAction;
 import javax.swing.BorderFactory;
@@ -46,6 +54,9 @@ import javax.swing.JTable;
 import javax.swing.LookAndFeel;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
+import javax.swing.text.JTextComponent;
+
+import static java.awt.EventQueue.invokeLater;
 
 public class AutoCompleteSupportTestApp {
 
@@ -192,6 +203,9 @@ public class AutoCompleteSupportTestApp {
     /** A checkbox to toggle whether the {@link #autoCompleteSupport} prefer a startsWith match when CONTAINS. */
     private final JCheckBox selectNonStrictContainsCheckBox = new JCheckBox();
 
+    /** A checkbox to toggle whether the {@link #autoCompleteSupport} puts the caret on the left or right side of a selection or text. */
+    private final JCheckBox positionCaretTowardZeroCheckBox = new JCheckBox();
+
     /** The ButtonGroup to which all Look & Feel radio buttons belong. */
     private final ButtonGroup lafMenuGroup = new ButtonGroup();
 
@@ -238,13 +252,17 @@ public class AutoCompleteSupportTestApp {
 
         selectTextOnFocusGainCheckBox.addActionListener(new SelectTextOnFocusGainActionHandler());
         selectTextOnFocusGainCheckBox.setSelected(autoCompleteSupport.getSelectsTextOnFocusGain());
-
+ 
         hidesPopupOnFocusLostCheckBox.addActionListener(new HidePopupOnFocusLostActionHandler());
         hidesPopupOnFocusLostCheckBox.setSelected(autoCompleteSupport.getHidesPopupOnFocusLost());
 
-
         selectNonStrictContainsCheckBox.addActionListener(new SelectNonStrictContainsActionHandler());
         selectNonStrictContainsCheckBox.setSelected(Boolean.TRUE.equals(autoCompleteComboBox.getClientProperty(GL_ENABLE_NON_STRICT_CONTAINS_SELECTION)));
+ 
+        if (hasPositionCaretTowardZero()) {
+            positionCaretTowardZeroCheckBox.addActionListener(new CaretTowardZeroActionHandler());
+            positionCaretTowardZeroCheckBox.setSelected(isPositionCaretTowardZero());
+        }
 
         frame.pack();
         frame.setLocationRelativeTo(null);
@@ -382,6 +400,59 @@ public class AutoCompleteSupportTestApp {
         }
     }
 
+
+    /**
+     * This is a little tricky, ideally only want to focus the autosupport combobox
+     * if it was focused when the button was pushed. Not worth figuring that out
+     * so always focus it and restore a selection, then finally invoke
+     * {@code setPositionCaretTowardZero}.
+     * Note that reflection is used so that this test file can be used with
+     * older versions of AutoCompleteSupport.
+     */
+    private class CaretTowardZeroActionHandler implements ActionListener {
+        @Override
+        public void actionPerformed(ActionEvent e)
+        {
+            JTextComponent ed = (JTextComponent)autoCompleteComboBox.getEditor().getEditorComponent();
+            int selectionStart = ed.getSelectionStart();
+            int selectionEnd = ed.getSelectionEnd();
+            
+            int stepTime = 50;
+            
+            CountDownLatch busy = new CountDownLatch(1);
+            ScheduledExecutorService exec = Executors.newScheduledThreadPool(2);
+            exec.schedule(() -> {
+                try {
+                    ScheduledFuture<?> step;
+                    
+                    // Before issuing setPositionCaretTowardZero, restore focus/combo state.
+                    // Let the button push finish
+                    step = exec.schedule(() -> {
+                        invokeLater(() -> autoCompleteComboBox.requestFocus());
+                    }, stepTime, TimeUnit.MILLISECONDS);
+                    step.get();
+                    
+                    // After AutoCompleteSupport focus gain operates then restore state
+                    step = exec.schedule(() -> {
+                        invokeLater(() -> ed.select(selectionStart, selectionEnd));
+                    }, stepTime, TimeUnit.MILLISECONDS);
+                    step.get();
+                    
+                    // After state restored then flip the switch
+                    step = exec.schedule(() -> {
+                        invokeLater(() -> setPositionCaretTowardZero(positionCaretTowardZeroCheckBox.isSelected()));
+                    }, stepTime, TimeUnit.MILLISECONDS);
+                    step.get();
+                    busy.countDown();
+                } catch(InterruptedException | ExecutionException ex) { }
+                try {
+                    busy.await();
+                    exec.shutdown();
+                } catch(InterruptedException ex) { }
+            }, 0, TimeUnit.MILLISECONDS);
+        }
+    }
+
     private class FilterModeActionHandler implements ActionListener {
         private final int mode;
 
@@ -412,23 +483,28 @@ public class AutoCompleteSupportTestApp {
     private JPanel createTweakerPanel() {
         final JPanel panel = new JPanel(new GridBagLayout());
 
-        panel.add(new JLabel("Corrects Case:"),             new GridBagConstraints(0, 0, 1, 1, 0.0, 0.0, GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(0, 0, 0, 5), 0, 0));
-        panel.add(correctsCaseCheckBox,                     new GridBagConstraints(1, 0, 1, 1, 0.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));
+        panel.add(new JLabel("Corrects Case:"),              new GridBagConstraints(0, 0, 1, 1, 0.0, 0.0, GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(0, 0, 0, 5), 0, 0));
+        panel.add(correctsCaseCheckBox,                      new GridBagConstraints(1, 0, 1, 1, 0.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));
 
-        panel.add(new JLabel("Strict:"),                    new GridBagConstraints(0, 1, 1, 1, 0.0, 0.0, GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(0, 0, 0, 5), 0, 0));
-        panel.add(strictModeCheckBox,                       new GridBagConstraints(1, 1, 1, 1, 0.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));
+        panel.add(new JLabel("Strict:"),                     new GridBagConstraints(0, 1, 1, 1, 0.0, 0.0, GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(0, 0, 0, 5), 0, 0));
+        panel.add(strictModeCheckBox,                        new GridBagConstraints(1, 1, 1, 1, 0.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));
 
-        panel.add(new JLabel("Select Text on Focus Gain:"), new GridBagConstraints(0, 2, 1, 1, 0.0, 0.0, GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(0, 0, 0, 5), 0, 0));
-        panel.add(selectTextOnFocusGainCheckBox,            new GridBagConstraints(1, 2, 1, 1, 0.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));
+        panel.add(new JLabel("Select Text on Focus Gain:"),  new GridBagConstraints(0, 2, 1, 1, 0.0, 0.0, GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(0, 0, 0, 5), 0, 0));
+        panel.add(selectTextOnFocusGainCheckBox,             new GridBagConstraints(1, 2, 1, 1, 0.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));
 
-        panel.add(new JLabel("Hide Popup on Focus Lost:"),  new GridBagConstraints(0, 3, 1, 1, 0.0, 0.0, GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(0, 0, 0, 5), 0, 0));
-        panel.add(hidesPopupOnFocusLostCheckBox,            new GridBagConstraints(1, 3, 1, 1, 0.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));
+        panel.add(new JLabel("Hide Popup on Focus Lost:"),   new GridBagConstraints(0, 3, 1, 1, 0.0, 0.0, GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(0, 0, 0, 5), 0, 0));
+        panel.add(hidesPopupOnFocusLostCheckBox,             new GridBagConstraints(1, 3, 1, 1, 0.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));
 
-        panel.add(new JLabel("Select NonStrict Contains:"), new GridBagConstraints(0, 4, 1, 1, 0.0, 0.0, GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(0, 0, 0, 5), 0, 0));
-        panel.add(selectNonStrictContainsCheckBox,          new GridBagConstraints(1, 4, 1, 1, 0.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));
+        panel.add(new JLabel("Select NonStrict Contains:"),  new GridBagConstraints(0, 4, 1, 1, 0.0, 0.0, GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(0, 0, 0, 5), 0, 0));
+        panel.add(selectNonStrictContainsCheckBox,           new GridBagConstraints(1, 4, 1, 1, 0.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));
 
-        panel.add(new JLabel("Filter Mode:"),               new GridBagConstraints(0, 6, 1, 1, 0.0, 0.0, GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(0, 0, 0, 5), 0, 0));
-        panel.add(filterModePanel,                          new GridBagConstraints(1, 6, 1, 1, 0.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));
+    if(hasPositionCaretTowardZero()) {
+        panel.add(new JLabel("Position Caret Toward Zero:"), new GridBagConstraints(0, 5, 1, 1, 0.0, 0.0, GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(0, 0, 0, 5), 0, 0));
+        panel.add(positionCaretTowardZeroCheckBox,           new GridBagConstraints(1, 5, 1, 1, 0.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));
+    }
+
+        panel.add(new JLabel("Filter Mode:"),                new GridBagConstraints(0, 6, 1, 1, 0.0, 0.0, GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(0, 0, 0, 5), 0, 0));
+        panel.add(filterModePanel,                           new GridBagConstraints(1, 6, 1, 1, 0.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));
 
         return panel;
     }
@@ -564,6 +640,38 @@ public class AutoCompleteSupportTestApp {
                 if (element.startsWith("http://www."))
                     baseList.add(element.substring(11));
             }
+        }
+    }
+
+    private static boolean hasPositionCaretTowardZero()  {
+        try {
+            AutoCompleteSupport.class.getMethod("setPositionCaretTowardZero", boolean.class);
+            return true;
+            //Method valueOfMethod = _clazz.getMethod("valueOf", String.class);
+        } catch(NoSuchMethodException | SecurityException ex) {
+            return false;
+        }
+    }
+
+    private boolean isPositionCaretTowardZero() {
+            //positionCaretTowardZeroCheckBox.setSelected(autoCompleteSupport.isPositionCaretTowardZero());
+        try {
+            Method method = AutoCompleteSupport.class.getMethod("isPositionCaretTowardZero");
+            Object result = method.invoke(autoCompleteSupport);
+            return (boolean)result;
+        } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException | IllegalArgumentException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    private void setPositionCaretTowardZero(boolean flag)
+            throws NumberFormatException {
+        
+        try {
+            Method method = AutoCompleteSupport.class.getMethod("setPositionCaretTowardZero", boolean.class);
+            method.invoke(autoCompleteSupport, flag);
+        } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException | IllegalArgumentException ex) {
+            throw new IllegalStateException(ex);
         }
     }
 }


### PR DESCRIPTION
Fix for #699. When 1.11  autocompletes, in the ComboBox Editor it does a java text selection of the characters after the user input. It does it in such a way that the caret ends up at the end of the match string. There are two problems with this (see img at #699)

- if the combo box is narrow, the user input and the insertion point are not visible. 
- The caret is not at the insertion point, contrary to typical behavior and expectations.

This PR adds a property PositionCaretTowardZero with getter/setter. When true, the caret is positioned at the left of the java text selection. For UI backwards compatibility it defaults to false.

I've left this as a draft PR because it adds methods. Instead, this could be controlled with a client property rather than by methods. After some experience, a future release could expose this feature as methods. Note that as a client property the behavior is less dynamic, with the set method, the caret is re-positioned when the method is invoked; this seems a minor consideration.